### PR TITLE
Add deleteTestCase and deleteTestSuite XML-RPC endpoints

### DIFF
--- a/cicd/tests/testcases/e2e/TC-E2E-001.yml
+++ b/cicd/tests/testcases/e2e/TC-E2E-001.yml
@@ -65,6 +65,28 @@ steps:
     expectPatterns:
       - "CI Smoke Test"
 
+  - name: Delete test case via API
+    command: |
+      curl -sf -X POST http://localhost:8090/lib/api/xmlrpc/v1/xmlrpc.php \
+        -H "Content-Type: text/xml" \
+        -d '<?xml version="1.0"?><methodCall><methodName>tl.deleteTestCase</methodName><params><param><value><struct>
+          <member><name>devKey</name><value><string>a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4</string></value></member>
+          <member><name>testcaseexternalid</name><value><string>CIT-1</string></value></member>
+        </struct></value></param></params></methodCall>'
+    expectPatterns:
+      - "Success|status.*1|true"
+
+  - name: Delete test suite via API
+    command: |
+      curl -sf -X POST http://localhost:8090/lib/api/xmlrpc/v1/xmlrpc.php \
+        -H "Content-Type: text/xml" \
+        -d '<?xml version="1.0"?><methodCall><methodName>tl.deleteTestSuite</methodName><params><param><value><struct>
+          <member><name>devKey</name><value><string>a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4</string></value></member>
+          <member><name>testsuiteid</name><value><int>2</int></value></member>
+        </struct></value></param></params></methodCall>'
+    expectPatterns:
+      - "Success|status.*1|true"
+
   - name: Tear down CI environment
     command: bash ./cicd/scripts/ci-down.sh
     timeout: 30000
@@ -75,4 +97,6 @@ criteria: |
   - Create a test suite under the project
   - Create a test case in the suite
   - Retrieve and verify the test case
+  - Delete the test case via tl.deleteTestCase
+  - Delete the test suite via tl.deleteTestSuite
   - Clean up the environment

--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -8191,6 +8191,104 @@ class TestlinkXMLRPCServer extends IXR_Server {
     }
 
     /**
+     * deleteTestCase
+     *
+     * Delete a test case identified by internal ID or external ID.
+     *
+     * @param struct $args
+     * @param string $args["devKey"]
+     * @param int $args["testcaseid"] - optional, internal ID
+     * @param string $args["testcaseexternalid"] - optional, external ID (e.g. "CIT-1")
+     *
+     * @return mixed $resultInfo
+     *        [status] => true/false of success
+     *        [id] => test case id
+     *        [message] => optional message for error message string
+     * @access public
+     */
+    public function deleteTestCase($args) {
+        $resultInfo = array();
+        $operation = __FUNCTION__;
+        $msg_prefix = "({$operation}) - ";
+
+        $this->_setArgs( $args );
+        $resultInfo[0]["status"] = false;
+
+        $checkFunctions = array(
+                'authenticate',
+                'checkTestCaseIdentity'
+        );
+        $status_ok = $this->_runChecks( $checkFunctions, $msg_prefix );
+
+        if($status_ok) {
+            $status_ok = $this->userHasRight( "mgt_modify_tc", self::CHECK_PUBLIC_PRIVATE_ATTR );
+            if(!$status_ok) {
+                $this->errors[] = new IXR_Error( INSUFFICIENT_RIGHTS, $msg_prefix . INSUFFICIENT_RIGHTS_STR );
+            }
+        }
+
+        if($status_ok) {
+            $tcaseID = $this->args[self::$testCaseIDParamName];
+            $this->tcaseMgr->delete( $tcaseID );
+            $resultInfo[0]["status"] = true;
+            $resultInfo[0]["id"] = $tcaseID;
+            $resultInfo[0]["message"] = GENERAL_SUCCESS_STR;
+            $resultInfo[0]["operation"] = $operation;
+        }
+
+        return $status_ok ? $resultInfo : $this->errors;
+    }
+
+    /**
+     * deleteTestSuite
+     *
+     * Delete a test suite and all its contents (child test cases and sub-suites).
+     *
+     * @param struct $args
+     * @param string $args["devKey"]
+     * @param int $args["testsuiteid"]
+     *
+     * @return mixed $resultInfo
+     *        [status] => true/false of success
+     *        [id] => test suite id
+     *        [message] => optional message for error message string
+     * @access public
+     */
+    public function deleteTestSuite($args) {
+        $resultInfo = array();
+        $operation = __FUNCTION__;
+        $msg_prefix = "({$operation}) - ";
+
+        $this->_setArgs( $args );
+        $resultInfo[0]["status"] = false;
+
+        $checkFunctions = array(
+                'authenticate',
+                'checkTestSuiteID'
+        );
+        $status_ok = $this->_runChecks( $checkFunctions, $msg_prefix );
+
+        if($status_ok) {
+            $status_ok = $this->userHasRight( "mgt_modify_tc", self::CHECK_PUBLIC_PRIVATE_ATTR );
+            if(!$status_ok) {
+                $this->errors[] = new IXR_Error( INSUFFICIENT_RIGHTS, $msg_prefix . INSUFFICIENT_RIGHTS_STR );
+            }
+        }
+
+        if($status_ok) {
+            $tsuiteID = $this->args[self::$testSuiteIDParamName];
+            $tsuiteMgr = new testsuite( $this->dbObj );
+            $tsuiteMgr->delete_deep( $tsuiteID );
+            $resultInfo[0]["status"] = true;
+            $resultInfo[0]["id"] = $tsuiteID;
+            $resultInfo[0]["message"] = GENERAL_SUCCESS_STR;
+            $resultInfo[0]["operation"] = $operation;
+        }
+
+        return $status_ok ? $resultInfo : $this->errors;
+    }
+
+    /**
      * Update value of Custom Field with scope='design'
      * for a given Test Suite
      *
@@ -9119,9 +9217,11 @@ class TestlinkXMLRPCServer extends IXR_Server {
                 'tl.createTestPlan' => 'this:createTestPlan',
                 'tl.createTestProject' => 'this:createTestProject',
                 'tl.createTestSuite' => 'this:createTestSuite',
+                'tl.deleteTestCase' => 'this:deleteTestCase',
                 'tl.deleteTestCaseSteps' => 'this:deleteTestCaseSteps',
                 'tl.deleteTestPlan' => 'this:deleteTestPlan',
                 'tl.deleteTestProject' => 'this:deleteTestProject',
+                'tl.deleteTestSuite' => 'this:deleteTestSuite',
                 'tl.uploadExecutionAttachment' => 'this:uploadExecutionAttachment',
                 'tl.uploadRequirementSpecificationAttachment' => 'this:uploadRequirementSpecificationAttachment',
                 'tl.uploadRequirementAttachment' => 'this:uploadRequirementAttachment',


### PR DESCRIPTION
## Summary

- Add `tl.deleteTestCase` endpoint — accepts `testcaseid` or `testcaseexternalid`
- Add `tl.deleteTestSuite` endpoint — accepts `testsuiteid`, deletes suite and all contents
- Both use `mgt_modify_tc` permission check, consistent with existing modify operations
- E2E test updated to exercise both delete endpoints after CRUD creation

Closes #1

## Test plan

- [x] `tl.deleteTestCase` with external ID returns success
- [x] `tl.deleteTestSuite` with suite ID returns success (deep delete)
- [x] All 5 CI tests pass locally (build, integration, e2e)
- [ ] CI pipeline passes on GitHub Actions (pending runner setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)