### PR TITLE
docs: introduce feature-request structure (FR-001..003)

### DIFF
--- a/docs/feature-requests/FR-001-extend-functional-test-coverage.md
+++ b/docs/feature-requests/FR-001-extend-functional-test-coverage.md
@@ -1,0 +1,109 @@
+---
+fr: FR-001
+title: Extend functional CI test coverage to plans, builds, executions, and requirements
+status: draft
+issue: https://github.com/dogkeeper886/testlink-code/issues/7
+authors: ["dogkeeper886"]
+created: 2026-04-19
+updated: 2026-04-19
+---
+
+# FR-001 — Extend functional CI test coverage
+
+## Tracking
+
+- GitHub issue: [#7](https://github.com/dogkeeper886/testlink-code/issues/7)
+- Status: draft
+- Depends on: [FR-002](./FR-002-delete-build-and-remove-test-case-from-test-plan.md) (cleaner Phase 1 teardown), [FR-003](./FR-003-requirement-spec-and-requirement-crud.md) (Phase 2 unblocked)
+- Blocks: None
+
+## Problem
+
+The CI suite landed by issue #5 covers project / suite / case CRUD plus smoke and auth — but it stops at the *static* setup of TestLink. The product's actual daily workflow (test plan → build → attach cases → record executions) and its compliance flow (requirement spec → requirement → assign to case → coverage report) have **zero automated coverage**.
+
+This means a regression in the execution-recording path — the part users touch every release — would ship unnoticed. Every "test result" assertion currently passes by virtue of the static entity API, not by virtue of TestLink actually doing what users use it for.
+
+## Goals
+
+- Validate the test-plan and build lifecycle through the XML-RPC API end-to-end.
+- Validate execution recording (pass / fail / blocked) and read-back via `getLastExecutionResult` and `getExecCountersByBuild`.
+- Validate requirement traceability (assign to case, coverage report) once the API supports requirement creation.
+- Stitch the dynamic flow into a single end-to-end workflow test (the `TC-WORKFLOW-002` analogue of the existing static `TC-WORKFLOW-001`).
+- All new tests follow the patterns in `cicd/TESTING_GUIDELINES.md`: dynamic IDs via `capture:`, `{{runId}}` / `{{testId}}` / `{{devKey}}` substitution, reverse-order teardown, full `objective` / `judgeContext` / `criteria` fields.
+
+## Non-goals
+
+- Negative tests (invalid IDs, malformed XML, FK violations, permission denials).
+- Security tests (injection, XSS, key-leak in errors, direct config fetch).
+- Performance tests (bulk create, concurrent reports).
+- Infra extensions (PHP extension presence, schema-migration idempotency, container user assertions).
+- Supporting features: keywords, custom fields, attachments, user/role administration.
+- Replacement of the YAML test runner with Vitest or another standard framework.
+
+## Proposed solution
+
+Three phases of new YAML testcases under `cicd/tests/testcases/`:
+
+```
+plan/
+  TC-PLAN-001  test plan CRUD
+  TC-PLAN-002  build CRUD under plan (closeBuild today; deleteBuild after FR-002)
+  TC-PLAN-003  attach case to plan (cascade-detach today; remove API after FR-002)
+
+execution/
+  TC-EXEC-001  record passing result
+  TC-EXEC-002  record fail then blocked (single test, one setup, status transitions)
+  TC-EXEC-003  counters per build via getExecCountersByBuild + getTotalsForTestPlan
+  TC-EXEC-004  delete execution and verify gone
+
+requirement/  (BLOCKED on FR-003)
+  TC-REQ-001   requirement spec CRUD
+  TC-REQ-002   requirement CRUD under spec
+  TC-REQ-003   assign requirement to case + getReqCoverage
+
+workflow/
+  TC-WORKFLOW-002  full plan-and-execute lifecycle
+                   (project → suite → case → plan → build → attach → report → read → reverse teardown)
+```
+
+Each test must verify each XML-RPC method exists in `lib/api/xmlrpc/v1/xmlrpc.class.php` before referencing it (the API surface map in issue #7 documents what's available today vs. what needs FR-002 / FR-003).
+
+## Alternatives considered
+
+- **Bigger single suite that covers everything in one giant flow.** Rejected — fails one-failure-blocks-all, makes diagnosis harder, doesn't isolate per-entity verification.
+- **Drive tests through the UI (Selenium / Playwright).** Rejected — slower, more brittle, doesn't exercise the API surface third-party integrations actually use. UI tests are a separate concern for a future FR.
+- **Wait for FR-003 before starting any of this.** Rejected — Phase 1 (execution flow) is the higher-value gap and is largely buildable today.
+
+## Acceptance criteria
+
+- Phase 1 and Phase 3 testcases pass under `bash cicd/scripts/run-tests.sh` (both simple judge and LLM judge).
+- Phase 2 testcases pass once FR-003 has landed.
+- Running each new suite twice in a row against a fresh stack produces identical results (idempotency).
+- No hardcoded IDs, names, or API keys in any new test step.
+- Each test's `objective` and `judgeContext` follow the patterns set in `TC-BUILD-002.yml` and `TC-AUTH-002.yml`.
+- Per-test logs in `cicd/results/<run>/<testId>.log` are non-empty for every test that talks to the running stack.
+- `TC-WORKFLOW-002` lives in `testcases/workflow/` so it joins the default run alongside `TC-WORKFLOW-001`.
+
+## Risks and tradeoffs
+
+- **Phase 1 written before FR-002 lands** uses cascade-deletion via `deleteTestPlan` for cleanup. When `deleteBuild` and `removeTestCaseFromTestPlan` arrive, those tests need a small refactor to use them properly. Mitigation: write a comment in each Phase 1 test pointing at FR-002 so the follow-up isn't forgotten.
+- **TC-EXEC-002 cycles statuses in one test.** If a single status transition fails, the whole test fails — slightly noisier diagnosis than three separate tests. Tradeoff accepted because setup cost is high and the transitions share state.
+- **Requirements coverage stays at zero** until FR-003 lands. If FR-003 slips, this FR's "compliance track" goal slips with it.
+
+## Open questions
+
+- _None._ The phased plan and the API surface map make scope unambiguous.
+
+## Implementation notes
+
+- Existing tests to copy from: `cicd/tests/testcases/crud/TC-CRUD-003.yml` (multi-entity CRUD with reverse teardown), `cicd/tests/testcases/workflow/TC-WORKFLOW-001.yml` (full flow with capture chain), `cicd/tests/testcases/auth/TC-AUTH-002.yml` (negative test framing in `judgeContext`).
+- API surface verification: `grep "'tl\\." lib/api/xmlrpc/v1/xmlrpc.class.php`.
+- The XML-RPC helper at `cicd/scripts/xmlrpc-capture.sh` produces stdout JSON envelopes and mirrors raw XML to stderr — `expectPatterns` matches against the combined stream.
+
+## Out of scope (deferred)
+
+- Negative-test suite — open a follow-up FR if needed after Phase 1 lands.
+- Security suite — open a follow-up FR after Phase 1 lands.
+- Performance suite — open a follow-up FR after Phase 1 lands.
+- Supporting features (keywords, custom fields, attachments, user admin) — separate FRs as the demand surfaces.
+- UI tests — separate FR, separate stack.

--- a/docs/feature-requests/FR-002-delete-build-and-remove-test-case-from-test-plan.md
+++ b/docs/feature-requests/FR-002-delete-build-and-remove-test-case-from-test-plan.md
@@ -1,0 +1,86 @@
+---
+fr: FR-002
+title: Add deleteBuild and removeTestCaseFromTestPlan to XML-RPC API
+status: draft
+issue: https://github.com/dogkeeper886/testlink-code/issues/8
+authors: ["dogkeeper886"]
+created: 2026-04-19
+updated: 2026-04-19
+---
+
+# FR-002 — Add `deleteBuild` and `removeTestCaseFromTestPlan` to XML-RPC API
+
+## Tracking
+
+- GitHub issue: [#8](https://github.com/dogkeeper886/testlink-code/issues/8)
+- Status: draft
+- Depends on: None
+- Blocks: [FR-001](./FR-001-extend-functional-test-coverage.md) Phase 1 (improves teardown shape; Phase 1 can start without this but will require rework when this lands)
+
+## Problem
+
+Two operations exist in the TestLink web UI but have no XML-RPC equivalent:
+
+- **No way to delete a build via API.** `tl.closeBuild` (mark inactive) and `tl.updateBuildCustomFieldsValues` (mutate custom fields) exist; outright delete does not. Tests that create a build to record an execution against can only "close" it, leaving rows in the DB across runs.
+- **No way to detach a case from a plan via API.** `tl.addTestCaseToTestPlan` exists with no inverse. Tests that exercise plan-attachment cannot cleanly detach the case afterward; subsequent runs see stale linkage.
+
+This forces test authors into one of three bad choices: rely on cascade via `deleteTestPlan`, leave residue, or seed/teardown directly in the DB. Issue #1 fixed the same shape of gap for `deleteTestCase` / `deleteTestSuite`; this FR finishes the job for builds and plan-case linkages.
+
+## Goals
+
+- Add `tl.deleteBuild(devKey, buildid)` that returns `<boolean>1</boolean>` on success, fault on FK violation when executions still attached.
+- Add `tl.removeTestCaseFromTestPlan(devKey, testplanid, testcaseid[, version])` that returns `<boolean>1</boolean>` on success, fault if the case is not attached to the plan.
+- Both methods registered in the XML-RPC dispatch map alongside existing entries.
+- Both wired to existing helper-class methods (the UI's path) — no new business logic.
+
+## Non-goals
+
+- Full `updateBuild` (beyond `updateBuildCustomFieldsValues`).
+- `updateTestPlan`, `updateTestProject`.
+- Cascade delete (force-drop attached executions when deleting a build) — listed as a Nice-to-have only.
+- Requirements API — covered by FR-003.
+
+## Proposed solution
+
+For each method:
+1. Add the public method to `lib/api/xmlrpc/v1/xmlrpc.class.php` following the shape of `deleteTestCase` (`xmlrpc.class.php:8209` — closest precedent, added by issue #1).
+2. Permission check: read the existing `closeBuild` (`xmlrpc.class.php:9018`) and `addTestCaseToTestPlan` (`xmlrpc.class.php:3461`) implementations; mirror their ACL scaffolding rather than guessing.
+3. Delegate to the existing helper-class method (build manager / test plan manager).
+4. Register the method name in the dispatch table alongside the others.
+5. If new error codes are introduced, add them to `lib/api/xmlrpc/v1/api.const.inc.php`.
+
+## Alternatives considered
+
+- **Cascade-delete builds when test plan is deleted.** Already happens implicitly via `deleteTestPlan`. But it's coarse — there's no way to delete a single misnamed build without nuking the plan. Rejected as the only mechanism.
+- **`removeTestCasesFromTestPlan` (plural batch).** Useful but a separate concern; the singular form covers the common case and matches the singular `addTestCaseToTestPlan`. Add later if needed.
+- **Skip the API and have tests use DB cleanup.** Rejected — would couple tests to schema details and break the "tests use only public API" principle established by issue #5.
+
+## Acceptance criteria
+
+- `tl.deleteBuild` and `tl.removeTestCaseFromTestPlan` both appear in `grep "'tl\\." lib/api/xmlrpc/v1/xmlrpc.class.php`.
+- Manual XML-RPC roundtrip for each: create the parent state → call the new method → read back and verify the entity is gone (or no longer attached).
+- The CI test suite (`cicd/tests/testcases/plan/`) under FR-001 can teardown cleanly without leaving builds or plan-case linkages behind.
+- FK violations return a clear fault response, not a 500 or silent success.
+
+## Risks and tradeoffs
+
+- **Permission model misjudgment.** Assuming "same as closeBuild" without verifying could over- or under-restrict. Mitigation: explicit instruction in the issue to read the actual implementation before mirroring.
+- **Order of teardown matters.** A `deleteBuild` that doesn't fault on attached executions would silently lose data. Mitigation: fault on FK violation by default, with cascade as Nice-to-have only.
+
+## Open questions
+
+- _Does `addTestCaseToTestPlan` track per-version attachment?_ (nice to resolve) — affects whether `removeTestCaseFromTestPlan` needs an optional `version` parameter. Read the helper to confirm before defining the signature.
+
+## Implementation notes
+
+- Reference patterns in the existing file:
+  - `addTestCaseToTestPlan` impl at `lib/api/xmlrpc/v1/xmlrpc.class.php:3461`
+  - `closeBuild` impl at `lib/api/xmlrpc/v1/xmlrpc.class.php:9018`
+  - `deleteTestCase` impl at `lib/api/xmlrpc/v1/xmlrpc.class.php:8209` (added by issue #1 — closest precedent for a delete operation)
+- Helper classes likely live in `lib/functions/` — search for `build_mgr` and `testplan` to find the existing manager methods to delegate to.
+
+## Out of scope (deferred)
+
+- `tl.updateBuild` (full update beyond custom fields) — open as a separate FR if/when needed.
+- `tl.updateTestPlan`, `tl.updateTestProject` — same.
+- Cascade-delete option (`force` flag) — listed Nice-to-have in issue #8; defer until a real test or user needs it.

--- a/docs/feature-requests/FR-003-requirement-spec-and-requirement-crud.md
+++ b/docs/feature-requests/FR-003-requirement-spec-and-requirement-crud.md
@@ -1,0 +1,103 @@
+---
+fr: FR-003
+title: Add Requirement Specification + Requirement CRUD to XML-RPC API
+status: draft
+issue: https://github.com/dogkeeper886/testlink-code/issues/9
+authors: ["dogkeeper886"]
+created: 2026-04-19
+updated: 2026-04-19
+---
+
+# FR-003 — Add Requirement Specification + Requirement CRUD to XML-RPC API
+
+## Tracking
+
+- GitHub issue: [#9](https://github.com/dogkeeper886/testlink-code/issues/9)
+- Status: draft
+- Depends on: None
+- Blocks: [FR-001](./FR-001-extend-functional-test-coverage.md) Phase 2 (requirement traceability tests cannot run without these methods)
+
+## Problem
+
+The XML-RPC API has read-only and traceability access to requirements but **no way to create, update, or delete the underlying entities**. A consumer can read a requirement, assign it to a case, and query coverage — but cannot author a requirement spec or a requirement at all.
+
+This means:
+- External integrations (e.g. importing requirements from Jira via API) must bypass the API and write directly to the DB.
+- The CI suite (FR-001 Phase 2) cannot validate the requirement traceability flow because there's no API path to set up the requirement entities the test would assign.
+- Any automation around the requirements feature is blocked at the front door.
+
+The underlying business logic exists — the web UI uses `requirement_mgr.class.php` and `requirement_spec_mgr.class.php` daily. The work is the XML-RPC adapter, not new business logic.
+
+## Goals
+
+- Add five new XML-RPC methods covering Requirement Spec and Requirement CRUD:
+  - `tl.createRequirementSpecification(devKey, testprojectid, name, scope[, parentid][, typ][, coverage])` → returns new spec id.
+  - `tl.deleteRequirementSpecification(devKey, reqspecid)` → returns boolean; faults on FK violation.
+  - `tl.createRequirement(devKey, reqspecid, testprojectid, docid, title, scope, coverage[, status][, type][, validity][, expected_coverage])` → returns new requirement id.
+  - `tl.deleteRequirement(devKey, reqid)` → returns boolean.
+  - `tl.getRequirementSpecificationsForTestProject(devKey, testprojectid)` → returns array of spec records.
+- All five methods registered in the XML-RPC dispatch map.
+- All five methods delegate to the existing helper classes (`requirement_mgr`, `requirement_spec_mgr`).
+
+## Non-goals
+
+- Requirement versioning operations.
+- Requirement-to-requirement parent/child links between *requirements* (specs already support nesting via `parentid`).
+- Custom-field write API for requirements (only design-time read exists today).
+- `tl.updateRequirement` / `tl.updateRequirementSpecification` — listed Nice-to-have only.
+- `tl.unassignRequirements` (inverse of `assignRequirements`) — listed Nice-to-have only.
+
+## Proposed solution
+
+Land one method end-to-end first, then replicate the pattern for the remaining four.
+
+Suggested order:
+1. `createRequirementSpecification` — establishes the dispatch + permission + helper-call shape.
+2. `getRequirementSpecificationsForTestProject` — read pair for #1; verifies #1 actually persisted.
+3. `deleteRequirementSpecification` — close the loop on the spec entity.
+4. `createRequirement` — same shape as #1 but the child entity.
+5. `deleteRequirement` — close the loop on the requirement entity.
+
+Each follows the same template:
+- Public method on `lib/api/xmlrpc/v1/xmlrpc.class.php` (parameter validation + permission check + helper delegation + response wrapping).
+- Permission check based on requirement-management ACL (read existing UI usage to confirm exact rights).
+- Delegate to the existing manager class method.
+- Register the method name in the dispatch table.
+
+## Alternatives considered
+
+- **Add only the two methods strictly needed by FR-001 Phase 2 (`createRequirement` + `deleteRequirement`).** Rejected — without spec CRUD, requirements have nowhere to live and the API still requires UI/DB intervention. False economy.
+- **Add bulk variants (`createRequirements` plural).** Rejected for v1 — singular form covers the common case; bulk can come later as a separate FR if performance demands it.
+- **Generate the methods from the existing UI handlers (codegen).** Rejected — the existing handlers mix presentation logic with business logic; cleaner to write thin adapters than to extract.
+
+## Acceptance criteria
+
+- All five Must methods appear in `grep "'tl\\." lib/api/xmlrpc/v1/xmlrpc.class.php`.
+- Manual XML-RPC roundtrip: create spec → create requirement under it → assign to a case → `getReqCoverage` shows the linkage → delete requirement → delete spec, all via XML-RPC only (no UI or DB seed).
+- FR-001 Phase 2 (TC-REQ-001/002/003) becomes implementable as scoped.
+
+## Risks and tradeoffs
+
+- **Surface area is bigger than FR-002** (5 methods vs. 2). Mitigation: explicit incremental delivery — one method end-to-end before fanning out. Each method is independently mergeable.
+- **Requirement schema has more fields than test entities** (custom field design values, coverage targets, expected_coverage, validity, status). Risk: API signature becomes wide. Mitigation: required vs. optional split; only the minimum viable set of params is required, the rest default sensibly per the helper.
+- **Permission scoping may differ from test-entity ACL** — requirements are a separate management area in TestLink. Mitigation: read existing UI `req*.php` files in `lib/requirements/` for the actual ACL pattern before mirroring.
+
+## Open questions
+
+- _Are requirement spec types user-defined or fixed enum?_ (nice to resolve) — affects whether `typ` param accepts an integer ID, a string name, or both.
+- _Does deleting a requirement cascade to its assignments to test cases?_ (blocking) — if not, callers need to call `unassignRequirements` first; documentation must say so.
+
+## Implementation notes
+
+- Helper classes already exist (UI uses them today): `lib/functions/requirement_mgr.class.php`, `lib/functions/requirement_spec_mgr.class.php`. The work is the XML-RPC adapter, not new business logic.
+- Reference impl patterns:
+  - `createTestSuite`, `deleteTestSuite` (issue #1) for create/delete shape on a parent-child entity.
+  - `getRequirements` (already exists) for read-list shape.
+- Registration site: same dispatch table edits as FR-002.
+
+## Out of scope (deferred)
+
+- `tl.updateRequirement` / `tl.updateRequirementSpecification` — open as follow-up FR after Must lands.
+- `tl.unassignRequirements` — open as follow-up FR; currently only matters if cascade on delete is not implemented.
+- Requirement versioning API — much bigger scope, separate FR if user demand emerges.
+- Requirement custom-field write API — separate FR.

--- a/docs/feature-requests/README.md
+++ b/docs/feature-requests/README.md
@@ -1,0 +1,45 @@
+# Feature Requests
+
+Durable design records for non-trivial changes. Each feature request (FR) is a markdown document paired with a GitHub issue.
+
+## Why both?
+
+| | GitHub issue | FR document |
+|---|---|---|
+| Lives where | github.com | repo (versioned) |
+| Editable by | issue commenters | PR review |
+| Carries | status, assignment, conversation | decisions, tradeoffs, rationale |
+| Survives | as long as the issue tracker exists | as long as the code does |
+
+The issue is the conversation surface. The FR is the design record that travels with the code. Both must link to each other.
+
+## Naming
+
+`FR-NNN-<slug>.md`
+
+- `NNN` — zero-padded 3-digit sequence number, never reused.
+- `<slug>` — lowercase, hyphens, ~6 words max, no articles or generic verbs.
+
+Numbering is independent of GitHub issue numbers. One FR can spawn multiple issues; one issue may not deserve an FR.
+
+## Lifecycle
+
+```
+draft  →  proposed  →  accepted  →  in-progress  →  done
+                                                 ↘  rejected
+                              ↘ superseded (any state → newer FR replaces it)
+```
+
+The `status` field in the FR's YAML frontmatter is authoritative. Update it as the work progresses.
+
+## Authoring
+
+Use the [`feature-request` skill](https://docs.claude.com/en/docs/claude-code/skills) (when working with Claude Code), or copy [`_template.md`](./_template.md) and fill in the sections. The skill produces both the FR doc and the GitHub issue and links them automatically.
+
+## Index
+
+| FR | Title | Status | Issue |
+|---|---|---|---|
+| [FR-001](./FR-001-extend-functional-test-coverage.md) | Extend functional test coverage | draft | [#7](https://github.com/dogkeeper886/testlink-code/issues/7) |
+| [FR-002](./FR-002-delete-build-and-remove-test-case-from-test-plan.md) | Add `deleteBuild` and `removeTestCaseFromTestPlan` | draft | [#8](https://github.com/dogkeeper886/testlink-code/issues/8) |
+| [FR-003](./FR-003-requirement-spec-and-requirement-crud.md) | Add Requirement Spec + Requirement CRUD | draft | [#9](https://github.com/dogkeeper886/testlink-code/issues/9) |

--- a/docs/feature-requests/README.md
+++ b/docs/feature-requests/README.md
@@ -34,7 +34,9 @@ The `status` field in the FR's YAML frontmatter is authoritative. Update it as t
 
 ## Authoring
 
-Use the [`feature-request` skill](https://docs.claude.com/en/docs/claude-code/skills) (when working with Claude Code), or copy [`_template.md`](./_template.md) and fill in the sections. The skill produces both the FR doc and the GitHub issue and links them automatically.
+The canonical way is to copy [`_template.md`](./_template.md), fill in the sections, open the matching GitHub issue, and link the two together (FR's `issue:` frontmatter ↔ a `Spec:` line at the top of the issue body).
+
+If you happen to use Claude Code, there's an optional personal skill (`~/.claude/skills/feature-request/`) that automates the create-and-link flow. It's not part of this repository — install it locally if you want it. Without it, the `_template.md` plus a few `gh issue` commands gets you the same result.
 
 ## Index
 

--- a/docs/feature-requests/_template.md
+++ b/docs/feature-requests/_template.md
@@ -1,0 +1,58 @@
+---
+fr: FR-NNN
+title: <One short sentence>
+status: draft
+issue: <URL or #N>
+authors: ["<name>"]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# FR-NNN — <Title>
+
+## Tracking
+
+- GitHub issue: <link>
+- Status: <status>
+- Depends on: <other FRs / issues, or "None">
+- Blocks: <other FRs / issues, or "None">
+
+## Problem
+
+What's broken or missing today, and who feels the pain. One short paragraph. If the answer is "no one feels pain yet, this is speculative," say that explicitly so the reader can weight it.
+
+## Goals
+
+What "done" looks like, in user-visible or system-observable terms. Bulleted, 3-7 items. Each goal should be testable.
+
+## Non-goals
+
+Explicit list of what this FR does NOT cover, especially adjacent things readers might assume are in scope.
+
+## Proposed solution
+
+How. Enough detail that another engineer could start building. Diagrams in ASCII are fine. Cite file paths and line numbers when referring to existing code.
+
+## Alternatives considered
+
+For each: what it is, why it was rejected. Even one sentence each is fine — the value is in showing the option was looked at.
+
+## Acceptance criteria
+
+Concrete, checkable conditions. Should map 1:1 with goals where possible. These become the test plan and the merge gate.
+
+## Risks and tradeoffs
+
+What can go wrong, what we're giving up, who needs to be notified. Be honest — the doc is more useful when it admits weaknesses.
+
+## Open questions
+
+Anything not yet decided. Mark each as `(blocking)` or `(nice to resolve)`.
+
+## Implementation notes
+
+Pointers to relevant code, related FRs, prior art. Optional but valuable for whoever picks the work up.
+
+## Out of scope (deferred)
+
+Items explicitly punted to later FRs/issues. Each item should ideally name the follow-up issue if one exists.


### PR DESCRIPTION
## Summary

Introduces `docs/feature-requests/` as the home for paired design records — durable, in-repo, versioned alongside the code. Each non-trivial GitHub issue gets a matching FR doc; the issue is the conversation surface, the FR is the decision record.

Bootstrapped with three FRs covering the currently open issues:

| FR | Title | Issue |
|---|---|---|
| FR-001 | Extend functional CI test coverage | #7 |
| FR-002 | Add `deleteBuild` + `removeTestCaseFromTestPlan` | #8 |
| FR-003 | Add Requirement Spec + Requirement CRUD | #9 |

Each issue has been edited to prepend a `Spec:` link to its FR. The link is bidirectional: FR's `issue:` frontmatter ↔ issue body's `Spec:` line.

A `_template.md` and `README.md` document the structure and lifecycle (`draft → proposed → accepted → in-progress → done`).

## Workflow

Authoring is automated via a Claude Code skill at `~/.claude/skills/feature-request/SKILL.md` (personal config, not committed). Two modes:
- **From scratch** — user provides a topic, skill creates both the FR doc and the GitHub issue, links them.
- **From existing issue** — skill reads an existing issue, structures it into the FR template, links bidirectionally.

The skill is portable — it runs against any repo with a `docs/feature-requests/` directory.

## Test plan

- [ ] Open each new FR doc; confirm front-matter links to the right issue.
- [ ] Open issues #7, #8, #9; confirm each starts with a `Spec:` link to its FR doc.
- [ ] Confirm `docs/feature-requests/README.md` index table matches the actual files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)