### PR TITLE
docs: CLAUDE.md + project-scoped skills + testcase authoring guide

### DIFF
--- a/.claude/skills/feature-request/SKILL.md
+++ b/.claude/skills/feature-request/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: feature-request
+description: Author a feature request document and link it bidirectionally with a GitHub issue. Use when a user asks to "draft a feature request", "open a feature spec", "write an FR for issue N", or wants to formalize an idea into a tracked spec doc + issue pair before any code is written.
+---
+
+# Feature request authoring
+
+This skill produces a **paired artifact** for any non-trivial change:
+1. A markdown spec at `docs/feature-requests/FR-NNN-<slug>.md` in the repository
+2. A GitHub issue with the same content, cross-linked
+
+The spec is the durable design record (versioned with the code, editable via PR). The issue is the conversation, status, and assignment surface. Neither replaces the other.
+
+## When to invoke
+
+- User says something like: "draft a feature request for X", "open an FR", "let's spec this out before coding", "write an FR for issue N"
+- An idea has emerged from chat that's worth more than a one-line issue — there are decisions, tradeoffs, dependencies, or scope concerns to capture
+- An existing GitHub issue is sketchy and the user wants a fuller spec backing it
+
+**Do NOT invoke for:**
+- Bug fixes (use a regular issue)
+- Trivial chores (rename, version bump, formatting)
+- Already-decided implementation work that's about to start (skip straight to a PR)
+
+## Modes
+
+### Mode A — From scratch (`new`)
+
+User provides a topic. You ask 3-5 clarifying questions to get enough material, then:
+1. Pick the next FR number by listing `docs/feature-requests/FR-*.md`
+2. Slugify the title
+3. Render the template (see below) into `docs/feature-requests/FR-NNN-<slug>.md`
+4. Create a GitHub issue with the same body via `gh issue create`
+5. Edit the FR doc to insert the issue URL into the front-matter and the "Tracking" section
+6. Edit the issue body to insert the FR doc path
+7. Stage both files for commit (don't commit unless the user says so)
+
+### Mode B — From existing issue (`from-issue <number>`)
+
+User points at an existing issue. You:
+1. `gh issue view <N> --json number,title,body,url`
+2. Pick the next FR number (sequential, not matching the issue number — issue numbers are reused/sparse, FR numbers are durable)
+3. Slugify the issue title
+4. Convert the issue body into the FR template structure (lift sections that map; flag gaps in "Open questions")
+5. Save as `docs/feature-requests/FR-NNN-<slug>.md`
+6. Edit the issue body to prepend a "Spec: [docs/feature-requests/FR-NNN-…](docs/feature-requests/FR-NNN-…)" line
+7. Stage the FR doc for commit
+
+### Mode C — Backfill multiple
+
+User points at several existing issues. Run Mode B for each, in number order. Stage all FR docs. One commit per FR is cleaner than one mega-commit.
+
+## Template
+
+Use this exact structure. Don't add sections unless the user asks. Don't drop sections — leave a placeholder like "_None._" if a section doesn't apply, so the structure stays predictable across docs.
+
+```markdown
+---
+fr: FR-NNN
+title: <One short sentence>
+status: draft        # draft | proposed | accepted | in-progress | done | rejected | superseded
+issue: <URL or #N>   # GitHub issue this FR pairs with
+authors: ["<name>"]  # optional
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# FR-NNN — <Title>
+
+## Tracking
+
+- GitHub issue: <link>
+- Status: <status>
+- Depends on: <other FRs / issues, or "None">
+- Blocks: <other FRs / issues, or "None">
+
+## Problem
+
+What's broken or missing today, and who feels the pain. One short paragraph. If the answer is "no one feels pain yet, this is speculative," say that explicitly so the reader can weight it.
+
+## Goals
+
+What "done" looks like, in user-visible or system-observable terms. Bulleted, 3-7 items. Each goal should be testable.
+
+## Non-goals
+
+Explicit list of what this FR does NOT cover, especially adjacent things readers might assume are in scope. Bulleted.
+
+## Proposed solution
+
+How. Enough detail that another engineer could start building. Diagrams in ASCII are fine. Cite file paths and line numbers when referring to existing code.
+
+## Alternatives considered
+
+For each: what it is, why it was rejected. Even one sentence each is fine — the value is in showing the option was looked at.
+
+## Acceptance criteria
+
+Concrete, checkable conditions. Bulleted. Should map 1:1 with goals where possible. These become the test plan and the merge gate.
+
+## Risks and tradeoffs
+
+What can go wrong, what we're giving up, who needs to be notified. Be honest — the doc is more useful when it admits weaknesses.
+
+## Open questions
+
+Anything not yet decided. Mark each as `(blocking)` or `(nice to resolve)`. Don't bury these — answering them is often what unblocks the work.
+
+## Implementation notes
+
+Pointers to relevant code, related FRs, prior art. Optional but valuable for whoever picks the work up.
+
+## Out of scope (deferred)
+
+Items explicitly punted to later FRs/issues. Each item should ideally name the follow-up issue if one exists.
+```
+
+## File and naming conventions
+
+- Path: `docs/feature-requests/FR-NNN-<slug>.md` where `NNN` is zero-padded 3-digit.
+- Slug: lowercase, words joined by `-`, max ~6 words. Strip articles ("the", "a"), punctuation, action verbs ("add", "implement") if they don't add information.
+- Numbering: sequential, never reused. Never re-use a number even if an FR is rejected — it stays as a record.
+- Status transitions:
+  - `draft` → `proposed` (ready for review)
+  - `proposed` → `accepted` (approved to implement)
+  - `accepted` → `in-progress` (PR opened)
+  - `in-progress` → `done` (merged) OR `rejected` (decision reversed)
+  - Any → `superseded` (replaced by a newer FR; link to the successor in the doc body)
+
+## Bidirectional linking
+
+The FR doc's `issue:` frontmatter field and the GitHub issue body must always agree. When you update one, update the other in the same operation. If you ever observe drift (FR points at issue X, issue X doesn't link back), fix it as part of the next edit.
+
+When closing the loop after a PR merges:
+1. Set the FR `status` to `done`
+2. Add a "Resolution" subsection at the bottom of the FR with the merge commit / PR link
+3. The GitHub issue is closed automatically by the PR's "Closes #N" — leave that alone
+
+## Concrete commands
+
+```bash
+# Pick next FR number
+ls docs/feature-requests/FR-*.md 2>/dev/null | sed 's/.*FR-\([0-9]*\)-.*/\1/' | sort -n | tail -1
+# Then increment and zero-pad to 3 digits.
+
+# Read an existing issue
+gh issue view <N> --repo <owner>/<repo> --json number,title,body,url
+
+# Create a new issue
+gh issue create --repo <owner>/<repo> --title "<title>" --body-file <fr-doc-path>
+
+# Update an existing issue body
+gh issue edit <N> --repo <owner>/<repo> --body-file <fr-doc-path>
+```
+
+## Anti-patterns to avoid
+
+- Don't create an FR for work the user has already started or merged. Document what was actually built, not a hypothetical plan.
+- Don't pad. If a section is genuinely empty, write `_None._` and move on. Empty placeholders ("TBD", "TODO") rot.
+- Don't promise dates. Status field carries the lifecycle; dates belong on the issue, not the spec.
+- Don't duplicate API surface tables or data the issue already has — link to the source. The FR is for *decisions*, the issue is for *conversation*, the code is for *truth*.
+- Don't number FRs to match issue numbers. They drift (one FR can spawn many issues; one issue may not deserve an FR).

--- a/.claude/skills/testcase-author/SKILL.md
+++ b/.claude/skills/testcase-author/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: testcase-author
+description: Author or review a TestLink CI test case YAML. Use when the user asks to "add a test for X", "write a testcase", "draft TC-...", or "review this testcase for pattern conformance". Keeps the objective / judgeContext / criteria fields aligned with what the LLM judge expects and avoids the priming-hallucination failure modes documented in cicd/tests/TESTCASE_AUTHORING.md.
+---
+
+# Authoring and reviewing TestLink testcases
+
+This skill operates on YAML testcases under `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml`. The canonical authoring guide is [`cicd/tests/TESTCASE_AUTHORING.md`](../../../cicd/tests/TESTCASE_AUTHORING.md) — read it before writing a new test or reviewing an existing one. Framework mechanics (dynamic IDs, teardown order) are in [`cicd/tests/TESTING_GUIDELINES.md`](../../../cicd/tests/TESTING_GUIDELINES.md).
+
+## When to invoke
+
+- User says: "add a test for X", "write TC-<SUITE>-<NNN>", "draft a testcase that exercises Y", "review this YAML for pattern conformance"
+- User has changed a YAML and wants feedback before committing
+- An LLM-judge failure needs triaging — is the test wrong or is the LLM hallucinating?
+
+## What this skill does
+
+Two modes:
+
+### Mode A — Author a new testcase
+
+1. Confirm the suite. If the user wants a test in a new suite (not in `SUITES` in `cicd/tests/src/config.ts`), add the suite to that array first — otherwise the test won't be discovered.
+2. Pick the next `TC-<SUITE>-NNN` number by listing existing files in `cicd/tests/testcases/<suite>/`.
+3. Start from the skeleton at the bottom of `TESTCASE_AUTHORING.md`.
+4. For each step: write a real XML-RPC call using `cicd/scripts/xmlrpc-capture.sh` — never shell out directly to `curl`. Use `{{devKey}}`, `{{runId}}`, `{{testId}}`, `{{projectId}}`, `{{suiteId}}`, etc. Never hardcode IDs or API keys.
+5. Capture each new entity's id via `capture:` and reference it in subsequent steps. No numeric literals in XML-RPC params except semantic constants (e.g., `step_number=1`, `version=1`).
+6. Teardown in reverse creation order as the last steps of the testcase.
+7. Write the three framing fields carefully (next section).
+8. Run the suite once before committing — the test should pass both the simple judge AND the LLM judge. If only the simple judge passes, re-read the LLM judge's reason and either:
+   - Tighten `expectPatterns` if the LLM caught a real false-positive.
+   - Tighten `judgeContext` if the LLM is primed to hallucinate (see "anti-patterns" below).
+
+### Mode B — Review an existing testcase
+
+Walk through this checklist. Flag each miss as a finding:
+
+**Structure**
+- [ ] `objective`, `judgeContext`, `criteria` all present and non-empty.
+- [ ] `dependencies` lists every earlier test the runner must have passed before this one.
+- [ ] Every step has a `name`, a `command`, and either `expectPatterns` or explicit `capture:`.
+- [ ] Test-case-level `timeout` generous enough for the slowest step (often setup+teardown).
+
+**Conventions**
+- [ ] `{{devKey}}` used everywhere, no hardcoded API key literals.
+- [ ] Every created entity has a `{{runId}}` or `{{testId}}` suffix in its name.
+- [ ] Entity IDs flow via `capture:` — no numeric literals in XML-RPC params except `step_number`/`version` style constants.
+- [ ] Teardown deletes in reverse creation order.
+- [ ] Suite name in the YAML matches the directory name.
+
+**LLM-judge precision**
+- [ ] `expectPatterns` are tight. Any `|` alternation has alternatives that independently prove the assertion — not one real assertion OR'd with a field that's always present regardless of correctness. (See TC-EXEC-003 history: `"build-{{testId}}-{{runId}}|total_tc"` let a false-positive through.)
+- [ ] For negative tests, the `judgeContext` opens with `THIS IS A NEGATIVE TEST —`.
+- [ ] For tests with 10+ steps, the `judgeContext`'s failure-modes list ends with a guardrail: `IMPORTANT FOR THE JUDGE: only flag these if evidence actually shows them.`
+- [ ] Assertion patterns prefer literal XML/JSON fragments (e.g., `<name>status</name><value><string>p</string>`) over loose word matches (`status|passed`).
+
+**Anti-patterns to call out**
+- [ ] Long speculative lists in judgeContext without a guardrail. Small-model judges (gemma3:4b) grab a phrase verbatim and use it as "reason" for fail even when evidence contradicts. Either shorten the list or mark it hypothetical.
+- [ ] `expectPatterns` that match on fields present in BOTH success and failure responses. These pass the simple judge silently even when the assertion doesn't hold.
+- [ ] `objective` that describes the mechanics (what the test does) instead of the purpose (what the test proves and why it matters).
+- [ ] Missing teardown for any entity created in setup. Even when the plan/project cascade would clean up, an explicit per-entity delete is preferred because it lets the test catch the delete-API regression too.
+
+## Output
+
+- Mode A: produce the YAML file, run the suite once, summarize the verdict. If either judge fails, iterate.
+- Mode B: a bulleted report by finding — "Issue: X; Severity: should-fix/worth-considering; Suggested fix: Y". Don't rewrite the YAML in the report; let the user decide scope.
+
+## Anti-patterns this skill specifically tries to prevent
+
+- **Using `curl` directly in steps.** Every XML-RPC call must go through `cicd/scripts/xmlrpc-capture.sh` — it mirrors the raw response to stderr (for expectPatterns) and produces a structured JSON envelope on stdout (for `capture:`). Direct `curl` calls bypass both.
+- **Putting new testcase YAML in the root or a random dir.** Always `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml`.
+- **Forgetting to register a new suite name in `cicd/tests/src/config.ts` (`SUITES` const).** If the suite isn't in that array, the test doesn't run.
+- **Running the test without the stack up.** The runner (`bash cicd/scripts/run-tests.sh`) handles ci-up/ci-down automatically — don't start containers manually unless explicitly debugging.

--- a/.claude/skills/testcase-author/SKILL.md
+++ b/.claude/skills/testcase-author/SKILL.md
@@ -1,72 +1,80 @@
 ---
 name: testcase-author
-description: Author or review a TestLink CI test case YAML. Use when the user asks to "add a test for X", "write a testcase", "draft TC-...", or "review this testcase for pattern conformance". Keeps the objective / judgeContext / criteria fields aligned with what the LLM judge expects and avoids the priming-hallucination failure modes documented in cicd/tests/TESTCASE_AUTHORING.md.
+description: Help an author or reviewer think through a CI testcase — what it's proving, what its evidence means, and how its criteria prove or disprove the claim. Use when the user asks to "write a test for X", "author TC-...", or "review this testcase". The skill guides the reasoning; it does not prescribe a template. Canonical guide is cicd/tests/TESTCASE_AUTHORING.md.
 ---
 
-# Authoring and reviewing TestLink testcases
+# Authoring or reviewing a testcase — guided thinking
 
-This skill operates on YAML testcases under `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml`. The canonical authoring guide is [`cicd/tests/TESTCASE_AUTHORING.md`](../../../cicd/tests/TESTCASE_AUTHORING.md) — read it before writing a new test or reviewing an existing one. Framework mechanics (dynamic IDs, teardown order) are in [`cicd/tests/TESTING_GUIDELINES.md`](../../../cicd/tests/TESTING_GUIDELINES.md).
+A testcase is a claim about the system and the evidence for that claim. The LLM judge reads three fields — `objective`, `judgeContext`, `criteria` — as a per-test prompt. This skill walks through the reasoning a good author or reviewer follows. It does not hand over a template; copy-pasted templates produce testcases that describe themselves instead of teaching the judge anything.
 
-## When to invoke
+Read [`cicd/tests/TESTCASE_AUTHORING.md`](../../../cicd/tests/TESTCASE_AUTHORING.md) first. It is the canonical source. For framework mechanics (lifecycle, dynamic IDs, teardown), see [`cicd/tests/TESTING_GUIDELINES.md`](../../../cicd/tests/TESTING_GUIDELINES.md).
 
-- User says: "add a test for X", "write TC-<SUITE>-<NNN>", "draft a testcase that exercises Y", "review this YAML for pattern conformance"
-- User has changed a YAML and wants feedback before committing
-- An LLM-judge failure needs triaging — is the test wrong or is the LLM hallucinating?
+## Two modes
 
-## What this skill does
+### Mode A — Authoring a new testcase
 
-Two modes:
+Don't start by writing YAML. Start by answering four questions.
 
-### Mode A — Author a new testcase
+1. **What claim about the system is this test making?**
+   One sentence. Not "this test calls X and asserts Y" — that's the *how*. The claim is the *why*: "the admin API key accepts valid clients", "executions persist with the reported status", "the Docker image builds reproducibly from the current Dockerfile."
+   
+   If you can't state a single clean claim, the test is trying to prove too many things. Split it.
 
-1. Confirm the suite. If the user wants a test in a new suite (not in `SUITES` in `cicd/tests/src/config.ts`), add the suite to that array first — otherwise the test won't be discovered.
-2. Pick the next `TC-<SUITE>-NNN` number by listing existing files in `cicd/tests/testcases/<suite>/`.
-3. Start from the skeleton at the bottom of `TESTCASE_AUTHORING.md`.
-4. For each step: write a real XML-RPC call using `cicd/scripts/xmlrpc-capture.sh` — never shell out directly to `curl`. Use `{{devKey}}`, `{{runId}}`, `{{testId}}`, `{{projectId}}`, `{{suiteId}}`, etc. Never hardcode IDs or API keys.
-5. Capture each new entity's id via `capture:` and reference it in subsequent steps. No numeric literals in XML-RPC params except semantic constants (e.g., `step_number=1`, `version=1`).
-6. Teardown in reverse creation order as the last steps of the testcase.
-7. Write the three framing fields carefully (next section).
-8. Run the suite once before committing — the test should pass both the simple judge AND the LLM judge. If only the simple judge passes, re-read the LLM judge's reason and either:
-   - Tighten `expectPatterns` if the LLM caught a real false-positive.
-   - Tighten `judgeContext` if the LLM is primed to hallucinate (see "anti-patterns" below).
+2. **What's the minimum scenario that would prove this claim?**
+   Walk backwards from the claim to the shortest sequence of operations that exercises it. Don't pad the test with incidental verification — each extra assertion is something that can misfire.
 
-### Mode B — Review an existing testcase
+3. **What will the evidence look like if the claim holds? If it doesn't?**
+   Be specific. Don't say "the response indicates success." Say: "stderr contains `<member><name>status</name><value><string>p</string></value></member>`; absence of that exact fragment, or presence of a `<fault>` envelope, is the disproof."
+   
+   If you can't describe the evidence shape confidently, you may not understand the API well enough yet. Go run the operations manually and inspect the real output before writing the test.
 
-Walk through this checklist. Flag each miss as a finding:
+4. **What would a new colleague need to know to interpret this evidence correctly?**
+   This is what `judgeContext` is for. The judge is a colleague who starts from zero every invocation. Teach it — but teach only what's needed to read *these* logs, not the whole system.
 
-**Structure**
-- [ ] `objective`, `judgeContext`, `criteria` all present and non-empty.
-- [ ] `dependencies` lists every earlier test the runner must have passed before this one.
-- [ ] Every step has a `name`, a `command`, and either `expectPatterns` or explicit `capture:`.
-- [ ] Test-case-level `timeout` generous enough for the slowest step (often setup+teardown).
+Once those are answered, the three fields write themselves:
+- **`objective`** ← answer to (1), plus why it matters.
+- **`judgeContext`** ← answer to (4).
+- **`criteria`** ← answer to (3), tightened to exact observable fragments.
 
-**Conventions**
-- [ ] `{{devKey}}` used everywhere, no hardcoded API key literals.
-- [ ] Every created entity has a `{{runId}}` or `{{testId}}` suffix in its name.
-- [ ] Entity IDs flow via `capture:` — no numeric literals in XML-RPC params except `step_number`/`version` style constants.
-- [ ] Teardown deletes in reverse creation order.
-- [ ] Suite name in the YAML matches the directory name.
+Then draft the YAML (steps, capture chain, teardown) using the skeleton mechanics in `TESTING_GUIDELINES.md`. Run the suite and read the verdict — if the judge fails, read its reason and check: is the criterion actually met in the evidence? If yes, either the criteria language is imprecise or the judgeContext is missing domain knowledge. Fix at the source.
 
-**LLM-judge precision**
-- [ ] `expectPatterns` are tight. Any `|` alternation has alternatives that independently prove the assertion — not one real assertion OR'd with a field that's always present regardless of correctness. (See TC-EXEC-003 history: `"build-{{testId}}-{{runId}}|total_tc"` let a false-positive through.)
-- [ ] For negative tests, the `judgeContext` opens with `THIS IS A NEGATIVE TEST —`.
-- [ ] For tests with 10+ steps, the `judgeContext`'s failure-modes list ends with a guardrail: `IMPORTANT FOR THE JUDGE: only flag these if evidence actually shows them.`
-- [ ] Assertion patterns prefer literal XML/JSON fragments (e.g., `<name>status</name><value><string>p</string>`) over loose word matches (`status|passed`).
+### Mode B — Reviewing a testcase
 
-**Anti-patterns to call out**
-- [ ] Long speculative lists in judgeContext without a guardrail. Small-model judges (gemma3:4b) grab a phrase verbatim and use it as "reason" for fail even when evidence contradicts. Either shorten the list or mark it hypothetical.
-- [ ] `expectPatterns` that match on fields present in BOTH success and failure responses. These pass the simple judge silently even when the assertion doesn't hold.
-- [ ] `objective` that describes the mechanics (what the test does) instead of the purpose (what the test proves and why it matters).
-- [ ] Missing teardown for any entity created in setup. Even when the plan/project cascade would clean up, an explicit per-entity delete is preferred because it lets the test catch the delete-API regression too.
+Walk through these questions. Record each as a finding. Severity is based on what breaks when it's wrong.
+
+**Is the claim clear?**
+- Reading only `objective`, do you understand what regression this test protects against?
+- Is it one claim, or is the field secretly listing three?
+
+**Is the evidence explained?**
+- Does `judgeContext` tell you what the logs *mean*, or does it retell the YAML's steps?
+- If a junior engineer read the logs and this field, could they interpret them correctly?
+- Is there speculation about failure modes the evidence couldn't actually reveal? (Those prime the judge to hallucinate.)
+
+**Are the criteria precise?**
+- Could a human verify the criteria against a log file without consulting the author?
+- If any criterion has regex alternation (`A|B`), does each alternative *independently* prove the claim? Or is one alternative a field that's always present anyway?
+- Do the criteria name the exact fragment in the exact place, or vaguely say "success" / "passed" / "valid"?
+
+**Are the three fields doing different work?**
+- Is `judgeContext` adding something the `objective` and the steps themselves don't already say?
+- Are `criteria` specific to observable evidence, or do they repeat the `objective` in different words?
+- All three together should be shorter than the steps block, not longer.
+
+**Mechanics (from `TESTING_GUIDELINES.md`, briefly):**
+- All IDs come from `capture:`, no hardcoded numeric literals in XML-RPC params.
+- `{{devKey}}` everywhere, no API key literals.
+- Teardown in reverse creation order.
+- Entity names carry `{{runId}}` or `{{testId}}`.
+- All XML-RPC through `cicd/scripts/xmlrpc-capture.sh`.
+
+## What NOT to do in either mode
+
+- **Don't prescribe a formula to the author.** If you find yourself saying "add `IMPORTANT FOR THE JUDGE:` to your context" or any other magic phrase, stop. Ask instead: *what does the author know about this test that the judge doesn't?* The author's answer IS the `judgeContext`. Formulas produce noise; domain knowledge produces signal.
+- **Don't grade the test against an LLM model's known quirks.** If a particular model hallucinates on long tests, that's a framework concern. The test author's job is to communicate the claim and evidence well; a well-written test will survive most models.
+- **Don't let a loose `expectPattern` slide** because the test currently passes. Loose patterns are silent future regressions. Tight is always better.
 
 ## Output
 
-- Mode A: produce the YAML file, run the suite once, summarize the verdict. If either judge fails, iterate.
-- Mode B: a bulleted report by finding — "Issue: X; Severity: should-fix/worth-considering; Suggested fix: Y". Don't rewrite the YAML in the report; let the user decide scope.
-
-## Anti-patterns this skill specifically tries to prevent
-
-- **Using `curl` directly in steps.** Every XML-RPC call must go through `cicd/scripts/xmlrpc-capture.sh` — it mirrors the raw response to stderr (for expectPatterns) and produces a structured JSON envelope on stdout (for `capture:`). Direct `curl` calls bypass both.
-- **Putting new testcase YAML in the root or a random dir.** Always `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml`.
-- **Forgetting to register a new suite name in `cicd/tests/src/config.ts` (`SUITES` const).** If the suite isn't in that array, the test doesn't run.
-- **Running the test without the stack up.** The runner (`bash cicd/scripts/run-tests.sh`) handles ci-up/ci-down automatically — don't start containers manually unless explicitly debugging.
+- **Mode A:** produce the YAML, run the suite once, report the verdict. If both judges pass on the first run, the authoring was probably good. If the LLM judge fails with a reason that cites something absent from the evidence, the `judgeContext` may need a concrete statement about what's *not* an error (e.g. "intermediate status values are expected — the final state is the verdict"). Fix specifically, don't generalize.
+- **Mode B:** a bulleted finding report. One line per finding: what's weak, why it matters, what would fix it. Don't rewrite the YAML — the author decides scope.

--- a/.claude/skills/testcase-author/SKILL.md
+++ b/.claude/skills/testcase-author/SKILL.md
@@ -1,80 +1,128 @@
 ---
 name: testcase-author
-description: Help an author or reviewer think through a CI testcase — what it's proving, what its evidence means, and how its criteria prove or disprove the claim. Use when the user asks to "write a test for X", "author TC-...", or "review this testcase". The skill guides the reasoning; it does not prescribe a template. Canonical guide is cicd/tests/TESTCASE_AUTHORING.md.
+description: Think through a CI testcase. In authoring mode, produces a new YAML under cicd/tests/testcases/<suite>/. In review mode, produces a short bulleted findings report (possibly empty). Invoke when the user asks to write a new test, author TC-..., or review an existing testcase for correctness and clarity. Canonical guide is cicd/tests/TESTCASE_AUTHORING.md — read it first.
 ---
 
-# Authoring or reviewing a testcase — guided thinking
+# Testcase authoring and review
 
-A testcase is a claim about the system and the evidence for that claim. The LLM judge reads three fields — `objective`, `judgeContext`, `criteria` — as a per-test prompt. This skill walks through the reasoning a good author or reviewer follows. It does not hand over a template; copy-pasted templates produce testcases that describe themselves instead of teaching the judge anything.
+A testcase is a claim about the system plus the evidence that proves the claim. Three YAML fields are the claim surface:
 
-Read [`cicd/tests/TESTCASE_AUTHORING.md`](../../../cicd/tests/TESTCASE_AUTHORING.md) first. It is the canonical source. For framework mechanics (lifecycle, dynamic IDs, teardown), see [`cicd/tests/TESTING_GUIDELINES.md`](../../../cicd/tests/TESTING_GUIDELINES.md).
+- `objective` — the claim, in terms a product stakeholder would recognize.
+- `judgeContext` — the domain knowledge a new colleague would need to interpret the evidence. Not a step narration; the YAML already has that.
+- `criteria` — the observable in the logs that proves or disproves the claim. Specific fragments, not vague success-words.
 
-## Two modes
+All three fields, plus the `expectPatterns` on each step, are read by both a regex-matching simple judge and an LLM semantic judge. They are the test-specific prompt to the judge.
 
-### Mode A — Authoring a new testcase
+This skill guides the reasoning; it does not hand over a template. Fill-in-the-blank tests end up describing themselves instead of teaching the judge anything.
 
-Don't start by writing YAML. Start by answering four questions.
+## Deliverables
 
-1. **What claim about the system is this test making?**
-   One sentence. Not "this test calls X and asserts Y" — that's the *how*. The claim is the *why*: "the admin API key accepts valid clients", "executions persist with the reported status", "the Docker image builds reproducibly from the current Dockerfile."
-   
-   If you can't state a single clean claim, the test is trying to prove too many things. Split it.
+- **Authoring mode** — a new YAML file at `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml`, plus a run of the suite to confirm both judges agree.
+- **Review mode** — a bulleted findings list. *It is valid for the list to be empty.* Do not invent findings to look thorough.
 
-2. **What's the minimum scenario that would prove this claim?**
-   Walk backwards from the claim to the shortest sequence of operations that exercises it. Don't pad the test with incidental verification — each extra assertion is something that can misfire.
+Each review finding: severity · one-line claim of what's weak · one-line why it matters. No more. No fix wording.
 
-3. **What will the evidence look like if the claim holds? If it doesn't?**
-   Be specific. Don't say "the response indicates success." Say: "stderr contains `<member><name>status</name><value><string>p</string></value></member>`; absence of that exact fragment, or presence of a `<fault>` envelope, is the disproof."
-   
-   If you can't describe the evidence shape confidently, you may not understand the API well enough yet. Go run the operations manually and inspect the real output before writing the test.
+---
 
-4. **What would a new colleague need to know to interpret this evidence correctly?**
-   This is what `judgeContext` is for. The judge is a colleague who starts from zero every invocation. Teach it — but teach only what's needed to read *these* logs, not the whole system.
+## Authoring mode — four questions before any YAML
 
-Once those are answered, the three fields write themselves:
-- **`objective`** ← answer to (1), plus why it matters.
-- **`judgeContext`** ← answer to (4).
-- **`criteria`** ← answer to (3), tightened to exact observable fragments.
+Don't open the editor until these are answered.
 
-Then draft the YAML (steps, capture chain, teardown) using the skeleton mechanics in `TESTING_GUIDELINES.md`. Run the suite and read the verdict — if the judge fails, read its reason and check: is the criterion actually met in the evidence? If yes, either the criteria language is imprecise or the judgeContext is missing domain knowledge. Fix at the source.
+1. **What claim about the system does this test make?**
+   One sentence, named in product terms. *"Admin API keys are accepted"*, not *"checkDevKey returns `<boolean>1</boolean>`"*. If you can't make one sentence, split the test.
 
-### Mode B — Reviewing a testcase
+2. **What's the smallest scenario that exercises the claim?**
+   Walk from the claim backward to the minimum sequence of operations. Each extra step is another thing that can mis-assert.
 
-Walk through these questions. Record each as a finding. Severity is based on what breaks when it's wrong.
+3. **What does the evidence look like, specifically, when the claim holds? When it doesn't?**
+   The exact XML fragment, at the exact field path, in the exact step's stderr. If you can't describe the success evidence and the failure evidence concretely, run the commands manually first.
 
-**Is the claim clear?**
-- Reading only `objective`, do you understand what regression this test protects against?
-- Is it one claim, or is the field secretly listing three?
+4. **What would a new colleague — who has never seen this API — need to interpret these logs correctly?**
+   That's the judgeContext. Teach only what's needed for *these* logs, not the whole system.
 
-**Is the evidence explained?**
-- Does `judgeContext` tell you what the logs *mean*, or does it retell the YAML's steps?
-- If a junior engineer read the logs and this field, could they interpret them correctly?
-- Is there speculation about failure modes the evidence couldn't actually reveal? (Those prime the judge to hallucinate.)
+The three fields then write themselves:
+- `objective` ← (1), plus one phrase on what regression it protects against.
+- `criteria` ← (3), tightened to exact observable fragments.
+- `judgeContext` ← (4).
 
-**Are the criteria precise?**
-- Could a human verify the criteria against a log file without consulting the author?
-- If any criterion has regex alternation (`A|B`), does each alternative *independently* prove the claim? Or is one alternative a field that's always present anyway?
-- Do the criteria name the exact fragment in the exact place, or vaguely say "success" / "passed" / "valid"?
+After the YAML is drafted, run `bash cicd/scripts/run-tests.sh --suite <suite>`. If both judges pass on first run, the authoring is likely sound. If the LLM judge flags the test for a reason the evidence doesn't actually show, the gap is in the judgeContext — add the *domain fact* the judge is missing, not a correction addressed to the judge.
 
-**Are the three fields doing different work?**
-- Is `judgeContext` adding something the `objective` and the steps themselves don't already say?
-- Are `criteria` specific to observable evidence, or do they repeat the `objective` in different words?
-- All three together should be shorter than the steps block, not longer.
+## Review mode
 
-**Mechanics (from `TESTING_GUIDELINES.md`, briefly):**
-- All IDs come from `capture:`, no hardcoded numeric literals in XML-RPC params.
+**Before reading the three fields, do the warm-up.** Read the steps and the captured evidence. Without consulting the objective / criteria, ask yourself: *does the claim this test appears to be making actually hold given these logs?*
+
+- If you can't tell — the test is unclear or under-evidenced. That's a finding.
+- If you can tell *yes*, but the simple judge's `expectPatterns` would also pass on a state where the answer would be *no* — that's a false-positive finding, and it's usually **must-fix**.
+
+Only after the warm-up, walk the fields with these questions.
+
+### Is the claim clear?
+- From `objective` alone, do you know what regression this test protects against?
+- Is it one claim, or several stapled together?
+
+### Is the evidence explained?
+- Does `judgeContext` add something the steps don't already show? Or does it retell what the YAML already says?
+- Could a new colleague read the logs + judgeContext and interpret them without asking the author?
+
+### Are the criteria precise?
+- If any criterion has regex alternation (`A|B`), does each alternative independently prove the claim? Or is one alternative a field that's present in *both* correct and regressed states?
+- Do the criteria name the exact fragment at the exact field path, or use vocabulary like *success*, *passed*, *valid*?
+
+### Are the three fields doing different work?
+- `objective` states the claim. `criteria` name the observable. `judgeContext` adds interpretive context.
+- Do they overlap or restate each other? Each should be doing its own job.
+- Together they should be shorter than the steps block, not longer.
+
+### The domain-vs-directive test
+
+Some `judgeContext` content is legitimately directive toward the judge; some is a workaround for the judge's weaknesses. Use this distinguisher:
+
+> **Would another human engineer, reading these logs for the first time, independently say this?**
+
+- Yes → domain knowledge. Keep it. Example: *"TestLink's execution model is latest-wins."*
+- No → model-steering. Example: *"IMPORTANT FOR THE JUDGE: don't conclude fail just because..."*. No human says this to another human about logs.
+
+Model-steering belongs in the framework's system prompt (`llm-judge.ts`), not repeated per-test. When you find it in a `judgeContext`, the finding is: *generic steering masquerading as per-test context.* The information may be correct; the framing is at the wrong layer.
+
+### Mechanics (from `TESTING_GUIDELINES.md`, for completeness)
+- IDs come from `capture:`, no numeric literals in XML-RPC params.
 - `{{devKey}}` everywhere, no API key literals.
 - Teardown in reverse creation order.
-- Entity names carry `{{runId}}` or `{{testId}}`.
+- Entity names carry `{{runId}}` / `{{testId}}`.
 - All XML-RPC through `cicd/scripts/xmlrpc-capture.sh`.
 
-## What NOT to do in either mode
+---
 
-- **Don't prescribe a formula to the author.** If you find yourself saying "add `IMPORTANT FOR THE JUDGE:` to your context" or any other magic phrase, stop. Ask instead: *what does the author know about this test that the judge doesn't?* The author's answer IS the `judgeContext`. Formulas produce noise; domain knowledge produces signal.
-- **Don't grade the test against an LLM model's known quirks.** If a particular model hallucinates on long tests, that's a framework concern. The test author's job is to communicate the claim and evidence well; a well-written test will survive most models.
-- **Don't let a loose `expectPattern` slide** because the test currently passes. Loose patterns are silent future regressions. Tight is always better.
+## Anti-patterns
 
-## Output
+1. **Don't prescribe specific phrases.** A finding says what's missing or vague; it does not dictate wording. Give the author the principle; let them pick words.
+2. **Don't forgive a loose pattern because the test currently passes.** If the simple judge would pass on a regressed state, the test is silently broken — surface it regardless of run history.
+3. **Don't manufacture findings.** A well-written test gets no findings. Saying so is the correct output.
+4. **Don't grade with model names.** Never frame a finding as "gemma3 will confuse this" or "qwen handles this better." The question is whether the test is a clear prompt, not whether a specific model handles it. Model-specific weaknesses are framework-level concerns.
 
-- **Mode A:** produce the YAML, run the suite once, report the verdict. If both judges pass on the first run, the authoring was probably good. If the LLM judge fails with a reason that cites something absent from the evidence, the `judgeContext` may need a concrete statement about what's *not* an error (e.g. "intermediate status values are expected — the final state is the verdict"). Fix specifically, don't generalize.
-- **Mode B:** a bulleted finding report. One line per finding: what's weak, why it matters, what would fix it. Don't rewrite the YAML — the author decides scope.
+---
+
+## Severity rubric
+
+- **Must fix** — the claim is wrong, or the criteria would pass on a regressed system. The test is broken or silently deceptive.
+- **Should fix** — the three fields are not cleanly doing their three jobs; a reader would be confused; framing is off but facts are right.
+- **Nice to tighten** — works today, but a foreseeable regression or API shape change would turn it into a must-fix. Usually loose patterns.
+
+## Output shapes
+
+**Authoring:**
+```
+Wrote: cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml
+Ran:   bash cicd/scripts/run-tests.sh --suite <suite>
+Result: simple X/Y, LLM X/Y
+Follow-up (only if needed): <one-line note on any iteration>
+```
+
+**Reviewing:**
+```
+TC-<SUITE>-NNN
+  [severity] <one-line finding> — <one-line why>
+
+TC-<SUITE>-NNN
+  No findings.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,70 +2,55 @@
 
 This repository is a fork of TestLink (PHP test management system). This file tells AI agents how to work in it.
 
-## What lives where
+## Orientation
 
-- **`lib/`** — Core PHP. XML-RPC server at `lib/api/xmlrpc/v1/xmlrpc.class.php` (91 registered methods; grep `'tl\.` to enumerate).
-- **`gui/`, `cfg/`, `install/`** — Web UI, config, and DB schema. Rarely touched.
-- **`cicd/`** — CI test framework and docker-compose for the test stack. This is where most AI-assisted work happens.
-  - `cicd/docker-compose.ci.yml` — CI stack (app on port 8091 by default; dev is 8090).
-  - `cicd/scripts/run-tests.sh` — session wrapper; sources `cicd/tests/.env`; guaranteed teardown via `trap EXIT`.
-  - `cicd/scripts/xmlrpc-capture.sh` — XML-RPC helper every YAML test step uses.
+- **`lib/`** — Core PHP. XML-RPC server at `lib/api/xmlrpc/v1/xmlrpc.class.php`. Enumerate the registered methods with `grep "'tl\." lib/api/xmlrpc/v1/xmlrpc.class.php`.
+- **`gui/`, `cfg/`, `install/`** — Web UI, config, and DB schema. Rarely touched in AI-assisted work.
+- **`cicd/`** — CI test framework and docker-compose for the test stack. Most AI-assisted work happens here.
+  - `cicd/docker-compose.ci.yml` — CI stack. Publishes on `${TL_PORT:-8091}`; dev stack on 8090.
+  - `cicd/scripts/run-tests.sh` — session wrapper. Sources `cicd/tests/.env`, guarantees teardown via `trap EXIT`, skips the lifecycle for the `build` suite.
+  - `cicd/scripts/xmlrpc-capture.sh` — the only thing YAML test steps should use to call the XML-RPC API. Never shell out to `curl` directly.
   - `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml` — test definitions.
   - `cicd/tests/TESTING_GUIDELINES.md` — framework mechanics (lifecycle, dynamic IDs, teardown).
-  - `cicd/tests/TESTCASE_AUTHORING.md` — how to write the LLM-judge-facing fields (`objective`, `judgeContext`, `criteria`).
-- **`docs/feature-requests/`** — Paired design records for every non-trivial change. Each FR links to a GitHub issue.
-- **`.claude/skills/`** — Project-scoped Claude Code skills (see "Skills" below).
+  - `cicd/tests/TESTCASE_AUTHORING.md` — how to think about `objective`, `judgeContext`, and `criteria` for the LLM judge.
+- **`docs/feature-requests/`** — paired design records. Each non-trivial change gets an FR doc linked to its GitHub issue before code is written.
+- **`.claude/skills/`** — project-scoped Claude Code skills (see "Skills" below).
 
 ## Main branch
 
-`testlink_1_9_20_fixed`. Inherited from upstream; not renamed to `main` because the fork still pulls from `TestLinkOpenSourceTRMS/testlink-code`. Workflows in `.github/workflows/` are `workflow_dispatch`-only (manual trigger).
+`testlink_1_9_20_fixed`. Inherited from upstream; not renamed to `main` because the fork still pulls from `TestLinkOpenSourceTRMS/testlink-code`.
+
+## GitHub workflows
+
+All workflows in `.github/workflows/` are `workflow_dispatch` only. They do not fire on push or PR. That is intentional — run them manually from the Actions tab when you want them. Do not change this to automatic triggers without an explicit instruction.
 
 ## Skills
 
-Skills live at `.claude/skills/<name>/SKILL.md`. They're committed to the repo so every collaborator (AI or human) has access to the same tooling.
+**Project-specific skills live in `.claude/skills/<name>/` and are committed to the repo.**
 
-**IMPORTANT: Project-specific skills NEVER go in `~/.claude/skills/`.** Anything about this repo, its testcases, its workflows, or its conventions belongs in `.claude/skills/<name>/` in the repo tree. User-folder skills are for cross-project tooling only. If you catch yourself putting project work into the user folder, stop and put it in `.claude/skills/` instead.
+Skills belong in the repo — not in `~/.claude/skills/` — so every collaborator (human or AI) starts with the same tooling. When adding a skill for this project, put it under `.claude/skills/` in this tree. If you notice a project skill sitting in the user folder, move it.
 
-Current skills in this repo:
-- `feature-request` — Author a feature request doc (`docs/feature-requests/FR-NNN-*.md`) paired with a GitHub issue. Use before starting any non-trivial change.
-- `testcase-author` — Author or review a CI test YAML. Use for anything under `cicd/tests/testcases/`.
+To see what skills currently exist here: `ls .claude/skills/`. Each skill's purpose is documented in its own `SKILL.md`.
 
-## Workflow conventions
+## Commit and PR conventions
 
-### Branches and PRs
-- Branch names: `issue-N-short-slug` for issues, `docs/short-slug` for docs-only work, `feat/...` or `fix/...` only if no issue exists.
-- Every non-trivial change gets an FR doc paired with a GitHub issue *before* code is written. Small fixes can skip the FR.
-- PR titles: conventional-commit style (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`). Reference issues via `Closes #N`.
+- Git identity for this repo is set locally to Shang Chieh Tseng / shangchieh.tseng@tsengsyu.com / dogkeeper886. Don't change it.
+- Branch names: `issue-N-short-slug` for tracked issues, `docs/short-slug` for docs-only work, `feat/...` or `fix/...` only when no issue exists.
+- Commit subjects follow Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`).
+- Every non-trivial change is paired with an FR doc + GitHub issue before code is written. Small one-file fixes can skip this.
+- PR descriptions reference issues with `Closes #N`. Merge deletes the branch.
 
-### Commits
-- `git config` for this repo is set to commit as Shang Chieh Tseng / shangchieh.tseng@tsengsyu.com / dogkeeper886. Don't change it.
-- No sudo for docker commands. If `docker ps` fails, the user account isn't in the docker group — stop and flag it.
+## Testing
 
-### Testing
-- `bash cicd/scripts/run-tests.sh` runs the full suite. It brings the stack up, runs all tests, and tears down via `trap EXIT` regardless of outcome.
-- `--suite <name>` filters by suite (`build`, `smoke`, `auth`, `crud`, `plan`, `execution`, `workflow`, `negative`, `regression`).
-- `build` suite skips ci-up/ci-down (it only exercises the image artifact).
-- Tests must pass both the simple judge (regex) and the LLM judge (semantic) to be green. If only one passes, read the failing judge's reason — it's often a real finding (the LLM caught a loose pattern the regex let through).
+- `bash cicd/scripts/run-tests.sh` runs the full suite. The wrapper brings the stack up, runs the tests, tears down on any exit path.
+- `--suite <name>` filters by suite. The set of valid suite names is the `SUITES` const in `cicd/tests/src/config.ts`. Registering a new suite directory means adding its name there.
+- A test is green only when both the simple judge (pattern match) and the LLM judge (semantic review) agree. A disagreement usually means one of them is wrong — read the reason before deciding which.
+- LLM judge configuration lives in `cicd/tests/.env` (`LLM_JUDGE_URL`, `LLM_JUDGE_MODEL`).
 
-### LLM judge
-- Config in `cicd/tests/.env`: `LLM_JUDGE_URL`, `LLM_JUDGE_MODEL`.
-- Current model is `gemma3:4b`. It's reliable on short tests but flakes on 10+ step multi-entity tests due to small-model long-context limits. Don't treat a single LLM-judge failure on a long test as dispositive without reading the actual stderr.
-- See `TESTCASE_AUTHORING.md` for how to write test fields that minimize LLM-judge flakiness.
+## Rules
 
-## Things not to do
-
-- **Don't run the test runner from inside a workflow** that's configured to fire on every push. All GitHub workflows in this repo are `workflow_dispatch` only; keep them that way.
-- **Don't `sudo docker`.** User's in the docker group.
-- **Don't put project-specific skills in `~/.claude/skills/`.** Always `.claude/skills/<name>/` here.
-- **Don't hardcode `a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4`** (the admin API key) in new test steps. Use `{{devKey}}` — it's injected from `TL_DEV_KEY` in `.env`.
-- **Don't hardcode entity IDs.** Capture every ID from its create-response. Grep for `testcaseid=1` / `testprojectid=1` / similar in new code as a lint check.
-- **Don't merge to main without the suite passing.** Simple judge: 19/19. LLM judge: whatever it says (known flake on ~0-3 multi-step tests with gemma3:4b).
-
-## Memory vs. this file
-
-Anything in this file is authoritative for AI-agent behavior in this repo. Personal memory (`~/.claude/projects/.../memory/`) is for cross-session continuity with one user and shouldn't override anything here.
-
-## Contacts
-
-- Upstream repo: `TestLinkOpenSourceTRMS/testlink-code` (issues disabled upstream; we track issues on our fork).
-- Fork: `dogkeeper886/testlink-code`.
+- Don't use `sudo` with docker. The user is in the docker group — if a docker command fails with a permission error, something is wrong, stop and report rather than escalating.
+- Don't hardcode the admin API key. Use `{{devKey}}` in test YAMLs and `$TL_DEV_KEY` in scripts. The value flows from `cicd/tests/.env` through the framework.
+- Don't hardcode entity IDs in test steps. Every ID comes from a prior step's `capture:`.
+- Don't put project-specific skills in `~/.claude/skills/`. They belong in `.claude/skills/` here.
+- Don't switch workflows to automatic triggers without an explicit instruction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md — Project guidance for AI agents
+
+This repository is a fork of TestLink (PHP test management system). This file tells AI agents how to work in it.
+
+## What lives where
+
+- **`lib/`** — Core PHP. XML-RPC server at `lib/api/xmlrpc/v1/xmlrpc.class.php` (91 registered methods; grep `'tl\.` to enumerate).
+- **`gui/`, `cfg/`, `install/`** — Web UI, config, and DB schema. Rarely touched.
+- **`cicd/`** — CI test framework and docker-compose for the test stack. This is where most AI-assisted work happens.
+  - `cicd/docker-compose.ci.yml` — CI stack (app on port 8091 by default; dev is 8090).
+  - `cicd/scripts/run-tests.sh` — session wrapper; sources `cicd/tests/.env`; guaranteed teardown via `trap EXIT`.
+  - `cicd/scripts/xmlrpc-capture.sh` — XML-RPC helper every YAML test step uses.
+  - `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml` — test definitions.
+  - `cicd/tests/TESTING_GUIDELINES.md` — framework mechanics (lifecycle, dynamic IDs, teardown).
+  - `cicd/tests/TESTCASE_AUTHORING.md` — how to write the LLM-judge-facing fields (`objective`, `judgeContext`, `criteria`).
+- **`docs/feature-requests/`** — Paired design records for every non-trivial change. Each FR links to a GitHub issue.
+- **`.claude/skills/`** — Project-scoped Claude Code skills (see "Skills" below).
+
+## Main branch
+
+`testlink_1_9_20_fixed`. Inherited from upstream; not renamed to `main` because the fork still pulls from `TestLinkOpenSourceTRMS/testlink-code`. Workflows in `.github/workflows/` are `workflow_dispatch`-only (manual trigger).
+
+## Skills
+
+Skills live at `.claude/skills/<name>/SKILL.md`. They're committed to the repo so every collaborator (AI or human) has access to the same tooling.
+
+**IMPORTANT: Project-specific skills NEVER go in `~/.claude/skills/`.** Anything about this repo, its testcases, its workflows, or its conventions belongs in `.claude/skills/<name>/` in the repo tree. User-folder skills are for cross-project tooling only. If you catch yourself putting project work into the user folder, stop and put it in `.claude/skills/` instead.
+
+Current skills in this repo:
+- `feature-request` — Author a feature request doc (`docs/feature-requests/FR-NNN-*.md`) paired with a GitHub issue. Use before starting any non-trivial change.
+- `testcase-author` — Author or review a CI test YAML. Use for anything under `cicd/tests/testcases/`.
+
+## Workflow conventions
+
+### Branches and PRs
+- Branch names: `issue-N-short-slug` for issues, `docs/short-slug` for docs-only work, `feat/...` or `fix/...` only if no issue exists.
+- Every non-trivial change gets an FR doc paired with a GitHub issue *before* code is written. Small fixes can skip the FR.
+- PR titles: conventional-commit style (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`). Reference issues via `Closes #N`.
+
+### Commits
+- `git config` for this repo is set to commit as Shang Chieh Tseng / shangchieh.tseng@tsengsyu.com / dogkeeper886. Don't change it.
+- No sudo for docker commands. If `docker ps` fails, the user account isn't in the docker group — stop and flag it.
+
+### Testing
+- `bash cicd/scripts/run-tests.sh` runs the full suite. It brings the stack up, runs all tests, and tears down via `trap EXIT` regardless of outcome.
+- `--suite <name>` filters by suite (`build`, `smoke`, `auth`, `crud`, `plan`, `execution`, `workflow`, `negative`, `regression`).
+- `build` suite skips ci-up/ci-down (it only exercises the image artifact).
+- Tests must pass both the simple judge (regex) and the LLM judge (semantic) to be green. If only one passes, read the failing judge's reason — it's often a real finding (the LLM caught a loose pattern the regex let through).
+
+### LLM judge
+- Config in `cicd/tests/.env`: `LLM_JUDGE_URL`, `LLM_JUDGE_MODEL`.
+- Current model is `gemma3:4b`. It's reliable on short tests but flakes on 10+ step multi-entity tests due to small-model long-context limits. Don't treat a single LLM-judge failure on a long test as dispositive without reading the actual stderr.
+- See `TESTCASE_AUTHORING.md` for how to write test fields that minimize LLM-judge flakiness.
+
+## Things not to do
+
+- **Don't run the test runner from inside a workflow** that's configured to fire on every push. All GitHub workflows in this repo are `workflow_dispatch` only; keep them that way.
+- **Don't `sudo docker`.** User's in the docker group.
+- **Don't put project-specific skills in `~/.claude/skills/`.** Always `.claude/skills/<name>/` here.
+- **Don't hardcode `a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4`** (the admin API key) in new test steps. Use `{{devKey}}` — it's injected from `TL_DEV_KEY` in `.env`.
+- **Don't hardcode entity IDs.** Capture every ID from its create-response. Grep for `testcaseid=1` / `testprojectid=1` / similar in new code as a lint check.
+- **Don't merge to main without the suite passing.** Simple judge: 19/19. LLM judge: whatever it says (known flake on ~0-3 multi-step tests with gemma3:4b).
+
+## Memory vs. this file
+
+Anything in this file is authoritative for AI-agent behavior in this repo. Personal memory (`~/.claude/projects/.../memory/`) is for cross-session continuity with one user and shouldn't override anything here.
+
+## Contacts
+
+- Upstream repo: `TestLinkOpenSourceTRMS/testlink-code` (issues disabled upstream; we track issues on our fork).
+- Fork: `dogkeeper886/testlink-code`.

--- a/cicd/tests/TESTCASE_AUTHORING.md
+++ b/cicd/tests/TESTCASE_AUTHORING.md
@@ -1,189 +1,120 @@
-# Authoring testcases — what the LLM judge reads
+# Authoring testcases — a thinking guide
 
-This document describes how to write the YAML fields that feed the LLM judge: `objective`, `judgeContext`, and `criteria`. For test framework mechanics (dynamic IDs, lifecycle scopes, teardown order), see [`TESTING_GUIDELINES.md`](./TESTING_GUIDELINES.md).
+When you write a testcase, you're not just running commands. You're asking the LLM judge a question: *did this test prove what it was meant to prove?* The three fields `objective`, `judgeContext`, and `criteria` are how you pose that question. Together they are the test-specific prompt the judge receives.
 
-A good testcase tells the judge:
-1. **What am I looking at?** (objective)
-2. **What does the evidence look like, and what would silent failure look like in this domain?** (judgeContext)
-3. **What exactly must be true for this to pass?** (criteria)
+Good testcases think clearly about three different things in three different fields. Bad testcases mash them together or describe the YAML back to itself.
 
-The simple judge (pattern matching) runs first and catches literal regressions. The LLM judge catches semantic regressions — output that looks successful but actually means something broken. Both must pass for a testcase to be considered green.
+This guide is about the thinking, not a template. For mechanics (framework lifecycle, dynamic IDs, teardown), see [`TESTING_GUIDELINES.md`](./TESTING_GUIDELINES.md).
 
 ---
 
-## The three fields, in order
+## What the judge has and what it lacks
 
-### `objective`
+The judge receives:
+- The evidence — raw stdout, stderr, and container logs from every step that ran.
+- Your three fields: objective, judgeContext, criteria.
 
-A single short paragraph. State:
-- What this test proves (the assertion in plain English).
-- Why it matters (what would break if this regressed).
+The judge does **not** receive:
+- Domain knowledge about TestLink. It doesn't know what `<boolean>1</boolean>` means in a `tl.checkDevKey` response. It doesn't know that `testplan_tcversions` rows are what "attached" looks like. You have to teach it.
+- The reason the test exists. It can read the YAML, but "what this test proves" is editorial — it comes from you.
 
-**Good:**
-```
-Confirm the admin API key seeded by init-db.sh is accepted by
-tl.checkDevKey. Every CRUD and workflow test depends on this key being
-usable; if it's rejected, the rest of the suite is meaningless.
-```
-
-**Bad:**
-```
-This test calls tl.checkDevKey with the admin key and expects the
-response to contain <boolean>1</boolean>.
-```
-(That's a description of what the test does. The objective should be the reason the test exists. Mechanics belong in `judgeContext`.)
-
-### `judgeContext`
-
-A multi-paragraph briefing for the judge. Covers:
-- **Situational framing**: what kind of test this is. For anything unusual (negative test, multi-status cycling, etc.), lead with a loud marker like `THIS IS A NEGATIVE TEST —`.
-- **Per-step narrative**: for each step, what command runs and what evidence it produces. Identify which step has the key assertion.
-- **Failure hints**: *short list* of silent failure modes the judge should watch for — with the phrase *"only relevant if evidence shows them"* when the list is long or the test has many steps.
-
-Keep this field as short as you can without dropping information the judge can't infer from the steps themselves. For tests with 10+ steps, be especially concise — long prompts degrade small-model accuracy.
-
-**Good (concise, short test):**
-```
-Step 1 runs `curl -sf` against $TL_URL/login.php and pipes through
-`grep -o "Login" | head -1`. A healthy run prints the single word
-"Login" on stdout.
-
-Silent failures to watch for:
-- HTTP 200 but page content is a PHP error page — grep finds nothing
-  and stdout is empty.
-- curl follows a redirect to a different page.
-```
-
-**Good (multi-step — explicit guardrail to prevent hallucination):**
-```
-Ten steps. Setup (1-6), exercise (7-8: report + read-back), teardown (9-10).
-
-Step 8 is the key assertion: the response stderr must contain the
-literal XML fragment "<name>status</name><value><string>p</string>"
-— the exact serialization of status=passed.
-
-IMPORTANT FOR THE JUDGE: if every expectPattern listed in criteria
-matches, this test PASSES. The list below is hypothetical; only flag
-an item if the observations actually show that symptom.
-
-Hypothetical failure modes (only relevant if evidence shows them):
-- Step 7 returns status:true but no execution row was written →
-  step 8 would show no status at all.
-- Step 8 stderr contains status field with a different value than "p".
-```
-
-**Bad:**
-```
-Silent failures to watch for:
-- The entity is in the wrong parent (suite attached to wrong project).
-- The pass report succeeds against a stale plan+build.
-- Teardown returns true but rows persist in DB.
-- Cache issues in the ORM layer might cause...
-```
-(Small models grab these verbatim as "reason" for a failure, even when the evidence shows the test passed. Speculative lists = hallucination fuel.)
-
-### `criteria`
-
-Explicit `PASS when:` and `FAIL when:` bullet lists. Each bullet points to a specific step and a specific expected pattern — ideally a literal XML/JSON fragment, not a loose word match.
-
-**Good:**
-```
-PASS when:
-- Step 7 stdout contains {"ok": true, "id": <number>}.
-- Step 8 stderr contains the literal
-  "<name>status</name><value><string>p</string>".
-- Steps 9-10 each return <boolean>1</boolean>.
-
-FAIL on any fault envelope, missing execution row on read-back, or
-status mismatch.
-```
-
-**Bad:**
-```
-PASS when counters are populated.
-FAIL when counters are empty.
-```
-(Vague. "Populated" isn't something regex can match; the simple judge would let a false-positive through — e.g. a counter response containing the build *name* but zero actual counts.)
-
-**Bad:**
-```
-expectPatterns:
-  - "build-{{testId}}-{{runId}}|total_tc"
-```
-(Alternation across a guaranteed-present field and a "real assertion" field lets anything pass. Either match on the field that actually proves the assertion, or use two separate asserts.)
+Everything the judge doesn't know has to come from your three fields. Everything it *does* know (from the raw evidence) doesn't need repeating.
 
 ---
 
-## The expectPatterns field — tight is better
+## The three fields, and the question each answers
 
-`expectPatterns` is the simple judge's contract. Once the simple judge passes, the LLM judge reads the same observations. If the simple judge's pattern is too loose, the LLM judge can catch the real issue and correctly FAIL the test — but that surfaces as "LLM flaky" rather than "test had a bug."
+### `objective` — *what claim about the system am I making?*
 
-**Tight:** match the exact literal fragment that proves the thing you're asserting.
-```yaml
-expectPatterns:
-  - "<name>status</name><value><string>p</string>"
-```
+A test is a claim about the system. `objective` is you stating that claim in plain terms. Not what the test *does* — what it *proves*, and why that matters.
 
-**Too loose:** alternate across fields that are usually present anyway.
-```yaml
-expectPatterns:
-  - "build-{{testId}}-{{runId}}|total_tc"   # build name is always present; total_tc may not be
-```
+If you can't state the claim in one sentence, the test is probably trying to prove too many things.
 
-Rule of thumb: if the regex has a pipe `|`, every alternative should independently prove the assertion. If one alternative is a field that's always there regardless of correctness, either drop it or split into two expectPatterns.
+Ask yourself: *if this test were removed and the regression it protects against shipped to production, what would break?* That sentence is your objective.
+
+### `judgeContext` — *what does the evidence mean in this domain?*
+
+The judge sees raw XML-RPC responses, build logs, curl output. It doesn't know what those mean until you say. This is where your domain knowledge goes.
+
+Ask yourself: *if a new colleague read this test's logs cold, what would they need to know to interpret them correctly?*
+
+Things that belong here:
+- What the response format represents semantically. ("XML-RPC `<boolean>1</boolean>` inside a methodResponse envelope means the call succeeded; a `<fault>` element means it didn't.")
+- Which part of the evidence is the actual assertion, if it's not obvious. ("The executions are layered inside `additionalInfo.with_tester[]`; `exec_qty` is the count per status.")
+- Unusual dynamics of the test. ("This is a negative test — a fault response is the expected outcome." / "This test reports multiple statuses in sequence; the last one is the verdict.")
+- What an error would look like in this domain, versus a success. (Judges can't tell from raw output alone whether an absent field is normal or a regression.)
+
+Things that do **not** belong here:
+- A narration of the steps. The YAML already shows what the test runs.
+- Speculation about things that *could* go wrong but aren't specifically detectable from the evidence. Vague warnings prime the judge to hallucinate.
+- Instructions to the judge about how to reason. The judge's role is set at the framework level, not in your YAML.
+
+### `criteria` — *what specific observation proves or disproves the claim?*
+
+Concrete, visible-in-the-evidence conditions. If a human read the logs and the criteria, they should be able to run the check themselves without consulting you.
+
+Ask yourself: *what's the most specific pattern that distinguishes this test's success from the adjacent failure modes?*
+
+Good criteria name the exact fragment you're looking for in the exact place you expect it. Vague criteria ("status is passed", "counters are populated") hide false-positives.
 
 ---
 
-## Lessons from this project's history
+## A worked example
 
-- **Negative tests need loud framing.** Without `THIS IS A NEGATIVE TEST —` in the judgeContext, the LLM will see a fault response and mark the test FAIL even though the fault is what we wanted. (See `TC-AUTH-002.yml`.)
-- **Long tests need `IMPORTANT FOR THE JUDGE:` guardrails.** Tests with 10+ steps consistently get false-failed by the small-model judge when the judgeContext lists speculative failure modes. The model grabs a phrase from the list and uses it as its "reason" for fail. Always end the failure-modes list with a reminder: only fail if evidence actually shows the symptom.
-- **Prefer literal XML fragments over word matches.** The XML-RPC responses are deterministic; there's no reason to match `"status|passed"` when you can match `<string>p</string>` inside a specific element path.
-- **Truncation keeps the start of the buffer.** If your assertion is near the end of a long stderr response, either bump `stdoutLimit`/`stderrLimit` in `CONFIG.llm`, or structure the test so the relevant fragment lands in the first N chars.
-- **Each test owns its data.** Entity names must include `{{runId}}` / `{{testId}}` and teardown must delete in reverse creation order. See `TESTING_GUIDELINES.md §5`.
+Suppose you're writing a test that reports a failing execution and reads it back.
+
+**Thinking, before writing:**
+
+- *Claim I'm making:* `reportTCResult` correctly persists a failing status, and the read-back API reflects it. If this regressed, dashboards would show wrong counts for failing test runs — a direct product regression.
+- *What the evidence looks like:* `reportTCResult` returns an XML-RPC response with `status:true` and the new execution id. `getLastExecutionResult` returns a struct whose `status` field is a single-char code (`p` / `f` / `b`). The failing case emits `<member><name>status</name><value><string>f</string></value></member>` — exactly that fragment.
+- *Domain knowledge the judge needs:* single-char status codes. Which call's response is which. That `<string>f</string>` alone could appear in many contexts; the element path matters.
+- *The observable that proves correctness:* the literal fragment `<name>status</name><value><string>f</string></value>` in the stderr of the read-back step.
+
+**What makes it into the three fields:**
+
+`objective`:
+> Verify that `reportTCResult` persists a failing status and that `getLastExecutionResult` reads it back correctly. A regression here would cause TestLink's execution dashboards and counter APIs to under-report failures — silently green release reports that should be red.
+
+`judgeContext`:
+> The evidence consists of two XML-RPC responses: one from `reportTCResult` (step N), one from `getLastExecutionResult` (step M). TestLink encodes execution status as a single character: `p` (passed), `f` (failed), `b` (blocked), or an empty string when no execution exists. The relevant fragment in the read-back response is `<name>status</name><value><string>f</string></value>` — the element path matters because "f" alone can appear elsewhere (e.g. a substring of "Success", field names).
+
+`criteria`:
+> - Step N stdout contains `{"ok": true, "id": <number>}`.
+> - Step M stderr contains the literal fragment `<name>status</name><value><string>f</string></value>`.
+> - Any fault envelope in either step is a failure.
+
+Notice what's *not* there: no step-by-step narration of what the YAML runs, no list of "things that could go wrong," no formulaic phrases. The author wrote three things they uniquely know: the *claim*, the *domain*, the *observable*.
 
 ---
 
-## Quick reference skeleton
+## Traps, by principle
 
-```yaml
-id: TC-<SUITE>-<NNN>
-name: <one-sentence test name>
-suite: <existing suite>
-priority: <1 or higher>
-timeout: <ms>
-dependencies:
-  - <TC-... that must have passed>
+### Trap 1: describing what the test does instead of what the logs mean
 
-steps:
-  - name: <step name>
-    command: |
-      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
-      <?xml ...>
-      XMLDOC
-    expectPatterns:
-      - <literal fragment that proves this step's assertion>
-    capture:
-      <varName>: <field name or path in xmlrpc-capture.sh JSON>
+The YAML already shows the steps. Your `judgeContext` should add something the judge can't see from the YAML alone — what those outputs *mean*. If your `judgeContext` reads like a README of the steps, you haven't added anything.
 
-objective: |
-  <one short paragraph: what this proves, why it matters>
+### Trap 2: loose criteria that mask false-positives
 
-judgeContext: |
-  <situational framing if unusual, e.g. NEGATIVE TEST>
+If the simplest-matching pattern in your criteria also matches on an uninteresting field (e.g. a build *name* that's always present, regardless of whether executions were actually counted), then a broken test will look green. Tight patterns on the exact thing that proves the claim — not the nearest field that usually exists.
 
-  <per-step narrative: what each step does, what evidence it emits>
+### Trap 3: speculating about failure modes the evidence can't reveal
 
-  IMPORTANT FOR THE JUDGE: <guardrail for long multi-step tests>
+A list of "things that might silently go wrong" sounds thorough, but it asks the judge to imagine. Imaginings are hallucinations. Only talk about things that would show up in the observable logs if they happened.
 
-  Hypothetical failure modes (only relevant if evidence shows them):
-  - <observable symptom 1>
-  - <observable symptom 2>
+### Trap 4: overfitting one test to many claims
 
-criteria: |
-  PASS when:
-  - <step N stdout/stderr contains exact pattern>
-  - ...
+A test that "also verifies" some tangential concern usually has loose criteria and a bloated `judgeContext`. Split it. One claim per test.
 
-  FAIL on <specific observable failure modes>
-```
+### Trap 5: forgetting that the judge starts from zero every call
+
+Each judgment is independent. The judge doesn't remember prior tests in the run. Don't write `judgeContext` that assumes context from earlier tests — everything it needs must be in this one test's fields.
+
+---
+
+## Signs of a well-authored test
+
+- Reading the `objective` alone, you understand why the test matters.
+- Reading the `judgeContext` alone, you understand what the logs represent without the YAML.
+- Reading the `criteria` alone, you could verify the test manually against a log file.
+- All three fields together are shorter than the steps block, not longer.
+- The test proves exactly one thing.

--- a/cicd/tests/TESTCASE_AUTHORING.md
+++ b/cicd/tests/TESTCASE_AUTHORING.md
@@ -1,0 +1,189 @@
+# Authoring testcases — what the LLM judge reads
+
+This document describes how to write the YAML fields that feed the LLM judge: `objective`, `judgeContext`, and `criteria`. For test framework mechanics (dynamic IDs, lifecycle scopes, teardown order), see [`TESTING_GUIDELINES.md`](./TESTING_GUIDELINES.md).
+
+A good testcase tells the judge:
+1. **What am I looking at?** (objective)
+2. **What does the evidence look like, and what would silent failure look like in this domain?** (judgeContext)
+3. **What exactly must be true for this to pass?** (criteria)
+
+The simple judge (pattern matching) runs first and catches literal regressions. The LLM judge catches semantic regressions — output that looks successful but actually means something broken. Both must pass for a testcase to be considered green.
+
+---
+
+## The three fields, in order
+
+### `objective`
+
+A single short paragraph. State:
+- What this test proves (the assertion in plain English).
+- Why it matters (what would break if this regressed).
+
+**Good:**
+```
+Confirm the admin API key seeded by init-db.sh is accepted by
+tl.checkDevKey. Every CRUD and workflow test depends on this key being
+usable; if it's rejected, the rest of the suite is meaningless.
+```
+
+**Bad:**
+```
+This test calls tl.checkDevKey with the admin key and expects the
+response to contain <boolean>1</boolean>.
+```
+(That's a description of what the test does. The objective should be the reason the test exists. Mechanics belong in `judgeContext`.)
+
+### `judgeContext`
+
+A multi-paragraph briefing for the judge. Covers:
+- **Situational framing**: what kind of test this is. For anything unusual (negative test, multi-status cycling, etc.), lead with a loud marker like `THIS IS A NEGATIVE TEST —`.
+- **Per-step narrative**: for each step, what command runs and what evidence it produces. Identify which step has the key assertion.
+- **Failure hints**: *short list* of silent failure modes the judge should watch for — with the phrase *"only relevant if evidence shows them"* when the list is long or the test has many steps.
+
+Keep this field as short as you can without dropping information the judge can't infer from the steps themselves. For tests with 10+ steps, be especially concise — long prompts degrade small-model accuracy.
+
+**Good (concise, short test):**
+```
+Step 1 runs `curl -sf` against $TL_URL/login.php and pipes through
+`grep -o "Login" | head -1`. A healthy run prints the single word
+"Login" on stdout.
+
+Silent failures to watch for:
+- HTTP 200 but page content is a PHP error page — grep finds nothing
+  and stdout is empty.
+- curl follows a redirect to a different page.
+```
+
+**Good (multi-step — explicit guardrail to prevent hallucination):**
+```
+Ten steps. Setup (1-6), exercise (7-8: report + read-back), teardown (9-10).
+
+Step 8 is the key assertion: the response stderr must contain the
+literal XML fragment "<name>status</name><value><string>p</string>"
+— the exact serialization of status=passed.
+
+IMPORTANT FOR THE JUDGE: if every expectPattern listed in criteria
+matches, this test PASSES. The list below is hypothetical; only flag
+an item if the observations actually show that symptom.
+
+Hypothetical failure modes (only relevant if evidence shows them):
+- Step 7 returns status:true but no execution row was written →
+  step 8 would show no status at all.
+- Step 8 stderr contains status field with a different value than "p".
+```
+
+**Bad:**
+```
+Silent failures to watch for:
+- The entity is in the wrong parent (suite attached to wrong project).
+- The pass report succeeds against a stale plan+build.
+- Teardown returns true but rows persist in DB.
+- Cache issues in the ORM layer might cause...
+```
+(Small models grab these verbatim as "reason" for a failure, even when the evidence shows the test passed. Speculative lists = hallucination fuel.)
+
+### `criteria`
+
+Explicit `PASS when:` and `FAIL when:` bullet lists. Each bullet points to a specific step and a specific expected pattern — ideally a literal XML/JSON fragment, not a loose word match.
+
+**Good:**
+```
+PASS when:
+- Step 7 stdout contains {"ok": true, "id": <number>}.
+- Step 8 stderr contains the literal
+  "<name>status</name><value><string>p</string>".
+- Steps 9-10 each return <boolean>1</boolean>.
+
+FAIL on any fault envelope, missing execution row on read-back, or
+status mismatch.
+```
+
+**Bad:**
+```
+PASS when counters are populated.
+FAIL when counters are empty.
+```
+(Vague. "Populated" isn't something regex can match; the simple judge would let a false-positive through — e.g. a counter response containing the build *name* but zero actual counts.)
+
+**Bad:**
+```
+expectPatterns:
+  - "build-{{testId}}-{{runId}}|total_tc"
+```
+(Alternation across a guaranteed-present field and a "real assertion" field lets anything pass. Either match on the field that actually proves the assertion, or use two separate asserts.)
+
+---
+
+## The expectPatterns field — tight is better
+
+`expectPatterns` is the simple judge's contract. Once the simple judge passes, the LLM judge reads the same observations. If the simple judge's pattern is too loose, the LLM judge can catch the real issue and correctly FAIL the test — but that surfaces as "LLM flaky" rather than "test had a bug."
+
+**Tight:** match the exact literal fragment that proves the thing you're asserting.
+```yaml
+expectPatterns:
+  - "<name>status</name><value><string>p</string>"
+```
+
+**Too loose:** alternate across fields that are usually present anyway.
+```yaml
+expectPatterns:
+  - "build-{{testId}}-{{runId}}|total_tc"   # build name is always present; total_tc may not be
+```
+
+Rule of thumb: if the regex has a pipe `|`, every alternative should independently prove the assertion. If one alternative is a field that's always there regardless of correctness, either drop it or split into two expectPatterns.
+
+---
+
+## Lessons from this project's history
+
+- **Negative tests need loud framing.** Without `THIS IS A NEGATIVE TEST —` in the judgeContext, the LLM will see a fault response and mark the test FAIL even though the fault is what we wanted. (See `TC-AUTH-002.yml`.)
+- **Long tests need `IMPORTANT FOR THE JUDGE:` guardrails.** Tests with 10+ steps consistently get false-failed by the small-model judge when the judgeContext lists speculative failure modes. The model grabs a phrase from the list and uses it as its "reason" for fail. Always end the failure-modes list with a reminder: only fail if evidence actually shows the symptom.
+- **Prefer literal XML fragments over word matches.** The XML-RPC responses are deterministic; there's no reason to match `"status|passed"` when you can match `<string>p</string>` inside a specific element path.
+- **Truncation keeps the start of the buffer.** If your assertion is near the end of a long stderr response, either bump `stdoutLimit`/`stderrLimit` in `CONFIG.llm`, or structure the test so the relevant fragment lands in the first N chars.
+- **Each test owns its data.** Entity names must include `{{runId}}` / `{{testId}}` and teardown must delete in reverse creation order. See `TESTING_GUIDELINES.md §5`.
+
+---
+
+## Quick reference skeleton
+
+```yaml
+id: TC-<SUITE>-<NNN>
+name: <one-sentence test name>
+suite: <existing suite>
+priority: <1 or higher>
+timeout: <ms>
+dependencies:
+  - <TC-... that must have passed>
+
+steps:
+  - name: <step name>
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml ...>
+      XMLDOC
+    expectPatterns:
+      - <literal fragment that proves this step's assertion>
+    capture:
+      <varName>: <field name or path in xmlrpc-capture.sh JSON>
+
+objective: |
+  <one short paragraph: what this proves, why it matters>
+
+judgeContext: |
+  <situational framing if unusual, e.g. NEGATIVE TEST>
+
+  <per-step narrative: what each step does, what evidence it emits>
+
+  IMPORTANT FOR THE JUDGE: <guardrail for long multi-step tests>
+
+  Hypothetical failure modes (only relevant if evidence shows them):
+  - <observable symptom 1>
+  - <observable symptom 2>
+
+criteria: |
+  PASS when:
+  - <step N stdout/stderr contains exact pattern>
+  - ...
+
+  FAIL on <specific observable failure modes>
+```


### PR DESCRIPTION
## Summary

Three docs-only artifacts that codify how AI agents (and humans collaborating with them) should work in this repo. No source or test changes.

- **`CLAUDE.md`** (repo root) — orientation doc that Claude Code auto-loads. Directory layout, workflow conventions, the skill rule (*project skills belong in `.claude/skills/`, not `~/.claude/skills/`*), LLM-judge config, and a things-not-to-do list (no `sudo docker`, no hardcoded IDs, no hardcoded API keys, workflows stay `workflow_dispatch` only).

- **`.claude/skills/feature-request/`** — moved here from my personal `~/.claude/skills/` so every collaborator sees the same tool. Authors paired FR docs + GitHub issues.

- **`.claude/skills/testcase-author/`** — new skill. Two modes:
  - Mode A drafts a new YAML testcase from the canonical skeleton, verifies it against the running stack, iterates on any LLM-judge feedback.
  - Mode B reviews an existing YAML against a checklist (structure, conventions, precision, anti-patterns).

- **`cicd/tests/TESTCASE_AUTHORING.md`** — human-readable companion. Explains `objective` / `judgeContext` / `criteria` with good/bad side-by-side examples, distills the hard lessons from this session (long speculative "silent failures" lists prime small-model judges to hallucinate; loose `expectPatterns` let false-positives through; negative tests need loud framing), and ends with a skeleton YAML.

## Rationale

We landed PR #12 (Phase 1 test coverage) with a known wobble: 2-3 of the long multi-step tests occasionally LLM-false-fail. Root cause was gemma3:4b's small-model long-context limits *combined with* speculative failure-mode lists in the `judgeContext` that the model grabs as its "reason" for fail. The next AI agent or human author needs this documented or they'll repeat the same mistakes.

This PR is a preventive rather than corrective change — nothing in the current suite is broken, but the next test author would have had to rediscover these lessons from scratch.

## Test plan

- [ ] Open `CLAUDE.md` and confirm it renders in GitHub's markdown.
- [ ] Open each of the three new `.md` files; verify the internal links resolve.
- [ ] Confirm `.claude/skills/feature-request/SKILL.md` content matches the version that was previously at `~/.claude/skills/`.

## Follow-ups

- TC-EXEC-003's loose `expectPattern` (documented as an anti-pattern in `TESTCASE_AUTHORING.md`) still exists in the test itself. Fix belongs to PR #12 or a separate follow-up — not this PR.
- Apply the testcase-author skill's review mode retroactively to the other 7 new Phase 1 tests to catch any other loose patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)