### PR TITLE
docs: FR-004 — LLM judge evidence grounding

### DIFF
--- a/.claude/skills/testcase-author/SKILL.md
+++ b/.claude/skills/testcase-author/SKILL.md
@@ -5,15 +5,21 @@ description: Think through a CI testcase. In authoring mode, produces a new YAML
 
 # Testcase authoring and review
 
-A testcase is a claim about the system plus the evidence that proves the claim. Three YAML fields are the claim surface:
+A testcase is judged by two judges with different jobs. Getting the division of labor right is the first thing a good author does.
 
+- **Simple judge (regex)** — literal character matching. Its contract is each step's `expectPatterns`. Use this for any claim you can state as a substring.
+- **LLM judge (semantic)** — the common-sense read a human QA would bring. Its contract is the test-level `objective` / `judgeContext` / `criteria`. Use this for the part of the claim that only a human-like read catches — silent failures where regex passes but the result is wrong.
+
+They are complementary, not redundant. Writing test-level `criteria` that restate regex patterns forces the LLM into the simple judge's role, where it performs worse (hallucinations, long-context drift). The canonical guide at `cicd/tests/TESTCASE_AUTHORING.md` explains this division; read it first.
+
+The four fields at a glance:
+
+- Step-level `expectPatterns` — literal substrings the regex enforces.
 - `objective` — the claim, in terms a product stakeholder would recognize.
-- `judgeContext` — the domain knowledge a new colleague would need to interpret the evidence. Not a step narration; the YAML already has that.
-- `criteria` — the observable in the logs that proves or disproves the claim. Specific fragments, not vague success-words.
+- `judgeContext` — the domain knowledge a new colleague would need to interpret the evidence. Not a step narration.
+- `criteria` — pass/fail narrated the way a human colleague would describe it over your shoulder. Not a repeat of the regex patterns.
 
-All three fields, plus the `expectPatterns` on each step, are read by both a regex-matching simple judge and an LLM semantic judge. They are the test-specific prompt to the judge.
-
-This skill guides the reasoning; it does not hand over a template. Fill-in-the-blank tests end up describing themselves instead of teaching the judge anything.
+This skill guides the reasoning; it does not hand over a template. Fill-in-the-blank tests end up describing themselves instead of teaching the judges anything.
 
 ## Deliverables
 
@@ -40,10 +46,11 @@ Don't open the editor until these are answered.
 4. **What would a new colleague — who has never seen this API — need to interpret these logs correctly?**
    That's the judgeContext. Teach only what's needed for *these* logs, not the whole system.
 
-The three fields then write themselves:
+The fields then write themselves — split between the two judges:
+- `expectPatterns` (per-step, simple judge) ← the literal substrings from (3).
 - `objective` ← (1), plus one phrase on what regression it protects against.
-- `criteria` ← (3), tightened to exact observable fragments.
 - `judgeContext` ← (4).
+- `criteria` ← narrated pass/fail (how a human would describe the outcome over your shoulder), NOT a repeat of the substring patterns. The substrings belong in `expectPatterns`.
 
 After the YAML is drafted, run `bash cicd/scripts/run-tests.sh --suite <suite>`. If both judges pass on first run, the authoring is likely sound. If the LLM judge flags the test for a reason the evidence doesn't actually show, the gap is in the judgeContext — add the *domain fact* the judge is missing, not a correction addressed to the judge.
 
@@ -64,12 +71,13 @@ Only after the warm-up, walk the fields with these questions.
 - Does `judgeContext` add something the steps don't already show? Or does it retell what the YAML already says?
 - Could a new colleague read the logs + judgeContext and interpret them without asking the author?
 
-### Are the criteria precise?
-- If any criterion has regex alternation (`A|B`), does each alternative independently prove the claim? Or is one alternative a field that's present in *both* correct and regressed states?
-- Do the criteria name the exact fragment at the exact field path, or use vocabulary like *success*, *passed*, *valid*?
+### Are the simple-judge and LLM-judge assertions in their right places?
+- Step `expectPatterns` should carry the literal substrings — the character-exact, regex-enforceable claims. A missing substring there is a real regex finding.
+- Test-level `criteria` should narrate pass/fail for a human reader, not restate the substrings. If the `criteria` field reads like a list of regex patterns with field paths, that's a finding: the claim has been pushed to the wrong judge. The LLM judge gets worse when forced into the regex's role.
+- If `expectPatterns` alternates on `A|B`, each alternative must independently prove the claim — otherwise a fault response that happens to include one of the fields will pass silently.
 
-### Are the three fields doing different work?
-- `objective` states the claim. `criteria` name the observable. `judgeContext` adds interpretive context.
+### Are the three test-level fields doing different work?
+- `objective` states the claim. `judgeContext` adds interpretive context (domain knowledge). `criteria` narrates pass/fail in human terms.
 - Do they overlap or restate each other? Each should be doing its own job.
 - Together they should be shorter than the steps block, not longer.
 

--- a/.claude/skills/testcase-author/SKILL.md
+++ b/.claude/skills/testcase-author/SKILL.md
@@ -76,6 +76,11 @@ Only after the warm-up, walk the fields with these questions.
 - Test-level `criteria` should narrate pass/fail for a human reader, not restate the substrings. If the `criteria` field reads like a list of regex patterns with field paths, that's a finding: the claim has been pushed to the wrong judge. The LLM judge gets worse when forced into the regex's role.
 - If `expectPatterns` alternates on `A|B`, each alternative must independently prove the claim — otherwise a fault response that happens to include one of the fields will pass silently.
 
+### Does `criteria` name the specific terms a reader would point at?
+- Narration without named landmarks is a trap. *"A reader should see the case as passed"* is too abstract — the LLM judge has nothing short to quote in its `evidence` output, so it dumps raw XML and truncates the JSON.
+- *"A reader should see the case returned with status 'p' (passed) in the getLastExecutionResult response"* names specific terms — "status 'p'", "getLastExecutionResult" — that are both human-verifiable and short-quotable.
+- The check: ask whether the criterion contains at least one short concrete noun (a status letter, a count, a specific field name, an id format) that actually appears in the evidence. If not, flag as **should fix** — the LLM will either paraphrase (ungrounded) or dump long quotes (truncate).
+
 ### Are the three test-level fields doing different work?
 - `objective` states the claim. `judgeContext` adds interpretive context (domain knowledge). `criteria` narrates pass/fail in human terms.
 - Do they overlap or restate each other? Each should be doing its own job.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,19 @@ To see what skills currently exist here: `ls .claude/skills/`. Each skill's purp
 - A test is green only when both the simple judge (pattern match) and the LLM judge (semantic review) agree. A disagreement usually means one of them is wrong — read the reason before deciding which.
 - LLM judge configuration lives in `cicd/tests/.env` (`LLM_JUDGE_URL`, `LLM_JUDGE_MODEL`).
 
+## The two judges have different jobs — do not make them compete
+
+This is a design principle, not a mechanical rule. Get it wrong and the suite gets noisier without getting sharper.
+
+- **Simple judge (regex):** literal character and string matching. Its job is to enforce *exact fragments must be present*. Configured per-step via `expectPatterns`.
+- **LLM judge (semantic):** the common-sense read a human QA would bring to a log. Its job is to catch *silent failures where the regex passes but the result is wrong* — counters that look populated but aren't, builds that completed mid-stream, status fields with unexpected neighboring values. Configured per-test via `criteria` + `judgeContext` + `objective`.
+
+They are **complementary**, not redundant. The simple judge's guarantees (exact match, no hallucination, fast) free the LLM judge to do what only it can — apply general engineering judgment to output it's seeing for the first time.
+
+**Author anti-pattern:** writing test-level `criteria` that are essentially regex patterns — *"stderr contains exactly `<name>status</name><value><string>p</string>`"*. This forces the LLM to do the simple judge's job, which it does worse (hallucinations, off-by-one, long-context confusion). The right shape is the opposite: put the exact fragment in the step's `expectPatterns` where regex enforces it; describe pass/fail in `criteria` the way a human engineer would narrate it — *"the plan's totals show one passing execution was counted"*.
+
+A useful test: would you describe this pass/fail condition the same way to a human colleague reading the log over your shoulder? If yes, it's LLM-judge language. If you'd instead point at a specific substring, it's simple-judge language — put it in `expectPatterns`.
+
 ## Rules
 
 - Don't use `sudo` with docker. The user is in the docker group — if a docker command fails with a permission error, something is wrong, stop and report rather than escalating.

--- a/cicd/tests/TESTCASE_AUTHORING.md
+++ b/cicd/tests/TESTCASE_AUTHORING.md
@@ -1,20 +1,38 @@
 # Authoring testcases — a thinking guide
 
-When you write a testcase, you're not just running commands. You're asking the LLM judge a question: *did this test prove what it was meant to prove?* The three fields `objective`, `judgeContext`, and `criteria` are how you pose that question. Together they are the test-specific prompt the judge receives.
-
-Good testcases think clearly about three different things in three different fields. Bad testcases mash them together or describe the YAML back to itself.
+When you write a testcase, you're writing for two judges with different jobs. Getting the division of labor wrong is the most common mistake; understanding it is the first thing.
 
 This guide is about the thinking, not a template. For mechanics (framework lifecycle, dynamic IDs, teardown), see [`TESTING_GUIDELINES.md`](./TESTING_GUIDELINES.md).
 
 ---
 
-## What the judge has and what it lacks
+## The two judges, and what each is for
 
-The judge receives:
-- The evidence — raw stdout, stderr, and container logs from every step that ran.
-- Your three fields: objective, judgeContext, criteria.
+Every test run is evaluated by both judges. A test is green only when both agree.
 
-The judge does **not** receive:
+**Simple judge — regex.** Fast, literal, never hallucinates. Its job is to enforce *the exact character sequence X must appear in the evidence*. Configured per-step via `expectPatterns`. Use it for any claim you can state as a literal substring.
+
+**LLM judge — semantic.** The common-sense read of the logs a human QA engineer would bring. Its job is to catch *silent failures where the regex passes but the result is wrong*: counters that look populated but are all zeros; a build that completed mid-stream without an explicit error; a status field with adjacent values that don't make sense. Configured per-test via `objective`, `judgeContext`, `criteria`.
+
+These are complementary, not redundant. **The simple judge's exactness frees the LLM judge to do what only it can** — apply general engineering judgment to output it's seeing for the first time. Writing LLM-facing `criteria` that restate what the regex already checks forces the LLM into the simple judge's role, where it performs worse (hallucinations, long-context drift, off-by-one substring misses).
+
+A useful check while writing: *would I describe this pass/fail condition the same way to a human colleague reading the log over my shoulder?* If yes, it belongs in `criteria` (LLM-facing). If instead you'd point to a specific substring, it belongs in `expectPatterns` on the relevant step (regex-facing).
+
+---
+
+## What each judge has
+
+**Simple judge has:**
+- Each step's stdout and stderr.
+- The `expectPatterns` array you defined for that step.
+- Nothing else. It does not read `objective` / `judgeContext` / `criteria`.
+
+**LLM judge has:**
+- The same evidence (truncated to the framework's limits).
+- The three YAML fields: `objective`, `judgeContext`, `criteria`.
+- A system prompt that defines its role.
+
+**The LLM judge does NOT have:**
 - Domain knowledge about TestLink. It doesn't know what `<boolean>1</boolean>` means in a `tl.checkDevKey` response. It doesn't know that `testplan_tcversions` rows are what "attached" looks like. You have to teach it.
 - The reason the test exists. It can read the YAML, but "what this test proves" is editorial — it comes from you.
 
@@ -49,13 +67,15 @@ Things that do **not** belong here:
 - Speculation about things that *could* go wrong but aren't specifically detectable from the evidence. Vague warnings prime the judge to hallucinate.
 - Instructions to the judge about how to reason. The judge's role is set at the framework level, not in your YAML.
 
-### `criteria` — *what specific observation proves or disproves the claim?*
+### `criteria` — *what does pass look like, narrated for a human?*
 
-Concrete, visible-in-the-evidence conditions. If a human read the logs and the criteria, they should be able to run the check themselves without consulting you.
+Plain-language pass/fail description. Read by the LLM judge, not the regex. If a human QA engineer were reading the logs over your shoulder, this is the running commentary you'd give them: *"the plan totals show one passing execution was counted"*, *"the fault envelope carries a real faultCode, not a silent zero-boolean"*, *"the build completed and the image was registered under the expected tag"*.
 
-Ask yourself: *what's the most specific pattern that distinguishes this test's success from the adjacent failure modes?*
+Ask yourself: *how would I describe this test's pass condition to a colleague?* If your answer is "stderr contains substring X at position Y" — that's simple-judge language; put it in the relevant step's `expectPatterns` instead. Save `criteria` for the semantic claim.
 
-Good criteria name the exact fragment you're looking for in the exact place you expect it. Vague criteria ("status is passed", "counters are populated") hide false-positives.
+Vague `criteria` ("the test should succeed", "the response looks reasonable") is too weak — it doesn't give the LLM anything concrete to anchor on. Over-specific `criteria` ("stderr contains exactly `<string>p</string>` at byte offset 465") forces the LLM into the regex's role. The sweet spot is narrated claims with just enough specificity that a human reader could verify them from the log alone.
+
+**Regex-facing patterns belong in each step's `expectPatterns`:** this is where literal fragments go. The simple judge enforces those character-for-character, fast and exactly. The LLM judge does not see them directly — it sees the evidence and your `criteria`, and independently forms a judgment.
 
 ---
 
@@ -65,25 +85,34 @@ Suppose you're writing a test that reports a failing execution and reads it back
 
 **Thinking, before writing:**
 
-- *Claim I'm making:* `reportTCResult` correctly persists a failing status, and the read-back API reflects it. If this regressed, dashboards would show wrong counts for failing test runs — a direct product regression.
-- *What the evidence looks like:* `reportTCResult` returns an XML-RPC response with `status:true` and the new execution id. `getLastExecutionResult` returns a struct whose `status` field is a single-char code (`p` / `f` / `b`). The failing case emits `<member><name>status</name><value><string>f</string></value></member>` — exactly that fragment.
-- *Domain knowledge the judge needs:* single-char status codes. Which call's response is which. That `<string>f</string>` alone could appear in many contexts; the element path matters.
-- *The observable that proves correctness:* the literal fragment `<name>status</name><value><string>f</string></value>` in the stderr of the read-back step.
+- *Claim I'm making:* `reportTCResult` persists a failing status, and the read-back API reflects it. If this regressed, dashboards would show wrong counts for failing test runs — a direct product regression.
+- *What the evidence looks like:* `reportTCResult` returns an XML-RPC response with `status:true` and the new execution id. `getLastExecutionResult` returns a struct whose `status` field is a single-char code (`p` / `f` / `b`). The failing case emits `<member><name>status</name><value><string>f</string></value></member>`.
+- *What the regex must enforce (simple judge work):* the literal fragment `<name>status</name><value><string>f</string></value>` has to appear in the read-back step's stderr. That's a substring check — no judgment needed, and the judgment-free check is fast and certain.
+- *What only a human-like read will catch (LLM judge work):* a response shape that says `status:true` but with a surrounding envelope that actually carries a warning or degraded state. A status code of `f` written inside an `additionalInfo` block instead of the top-level result. Anything where the regex says "yes" but a human would say "wait, that's not right."
+- *Domain knowledge the judge needs:* that TestLink uses single-char status codes, that the path matters (`f` alone could appear as a substring elsewhere), that the read-back step is where the assertion lives.
 
-**What makes it into the three fields:**
+**What makes it into the three fields plus the step:**
+
+The step's `expectPatterns`:
+```yaml
+expectPatterns:
+  - "<name>status</name><value><string>f</string>"
+```
+That's the regex-facing assertion. Character-exact, fast, no hallucination.
 
 `objective`:
 > Verify that `reportTCResult` persists a failing status and that `getLastExecutionResult` reads it back correctly. A regression here would cause TestLink's execution dashboards and counter APIs to under-report failures — silently green release reports that should be red.
 
 `judgeContext`:
-> The evidence consists of two XML-RPC responses: one from `reportTCResult` (step N), one from `getLastExecutionResult` (step M). TestLink encodes execution status as a single character: `p` (passed), `f` (failed), `b` (blocked), or an empty string when no execution exists. The relevant fragment in the read-back response is `<name>status</name><value><string>f</string></value>` — the element path matters because "f" alone can appear elsewhere (e.g. a substring of "Success", field names).
+> The evidence consists of two XML-RPC responses: one from `reportTCResult` (a report acknowledgement), one from `getLastExecutionResult` (the read-back). TestLink encodes execution status as a single character: `p` (passed), `f` (failed), `b` (blocked), empty for no-execution. The read-back response is the source of truth — if it carries `status=f`, the failure was persisted correctly.
 
 `criteria`:
-> - Step N stdout contains `{"ok": true, "id": <number>}`.
-> - Step M stderr contains the literal fragment `<name>status</name><value><string>f</string></value>`.
-> - Any fault envelope in either step is a failure.
+> Pass: the fail report is acknowledged, and the read-back response shows the same case as failed. A human reading the logs should see both the acknowledgement and the post-report state matching.
+> Fail: the read-back shows a different status, or a fault envelope indicates the report didn't persist.
 
-Notice what's *not* there: no step-by-step narration of what the YAML runs, no list of "things that could go wrong," no formulaic phrases. The author wrote three things they uniquely know: the *claim*, the *domain*, the *observable*.
+Notice what's *not* in the `criteria`: character-level substrings. Those went into `expectPatterns`, where they belong. The `criteria` is narrated for a reader; the regex does the character-level work.
+
+Notice also what's not there: no step-by-step narration of what the YAML runs, no list of "things that could go wrong," no formulaic phrases. The author wrote three things they uniquely know: the *claim*, the *domain*, the *narrated pass/fail*.
 
 ---
 

--- a/cicd/tests/TESTCASE_AUTHORING.md
+++ b/cicd/tests/TESTCASE_AUTHORING.md
@@ -67,15 +67,35 @@ Things that do **not** belong here:
 - Speculation about things that *could* go wrong but aren't specifically detectable from the evidence. Vague warnings prime the judge to hallucinate.
 - Instructions to the judge about how to reason. The judge's role is set at the framework level, not in your YAML.
 
-### `criteria` — *what does pass look like, narrated for a human?*
+### `criteria` — *narrated pass/fail, naming the terms a reader would notice*
 
-Plain-language pass/fail description. Read by the LLM judge, not the regex. If a human QA engineer were reading the logs over your shoulder, this is the running commentary you'd give them: *"the plan totals show one passing execution was counted"*, *"the fault envelope carries a real faultCode, not a silent zero-boolean"*, *"the build completed and the image was registered under the expected tag"*.
+Plain-language pass/fail description, read by the LLM judge. Two things matter:
 
-Ask yourself: *how would I describe this test's pass condition to a colleague?* If your answer is "stderr contains substring X at position Y" — that's simple-judge language; put it in the relevant step's `expectPatterns` instead. Save `criteria` for the semantic claim.
+1. **Narrated** — like commentary to a human colleague reading the logs over your shoulder, not a regex schema.
+2. **Named** — specific domain terms the reader would *point at*. "Status 'p' (passed)", "exec_qty of 1 in the p bucket", "faultCode 2000", "the build's sha256 id". Short, concrete nouns that actually appear in the evidence.
 
-Vague `criteria` ("the test should succeed", "the response looks reasonable") is too weak — it doesn't give the LLM anything concrete to anchor on. Over-specific `criteria` ("stderr contains exactly `<string>p</string>` at byte offset 465") forces the LLM into the regex's role. The sweet spot is narrated claims with just enough specificity that a human reader could verify them from the log alone.
+These two properties are both needed. Here are three phrasings of the same claim, showing the gradient:
 
-**Regex-facing patterns belong in each step's `expectPatterns`:** this is where literal fragments go. The simple judge enforces those character-for-character, fast and exactly. The LLM judge does not see them directly — it sees the evidence and your `criteria`, and independently forms a judgment.
+```
+BAD (regex-dictation):
+  Step 8 stderr contains the literal fragment
+  <name>status</name><value><string>p</string>.
+
+BAD (too abstract):
+  A reader should see the case as passed in the read-back.
+
+GOOD (narrated + named):
+  A reader should see the case returned with status 'p' (passed)
+  in the getLastExecutionResult response.
+```
+
+The first form forces the LLM to do the simple judge's job (character-level matching). The second form gives the LLM nothing specific to cite — it reasons correctly but then reaches into the raw observations for something to quote, often dumping a verbose XML block that blows the output budget. The third form narrates for a human *and* provides short named landmarks the LLM can lift into its `evidence` output without going long.
+
+**Named terms do double duty.** They make the criterion concrete enough for a human to verify, and they hand the LLM judge a short quotable anchor. Without them, the evidence field either paraphrases the criterion text (ungrounded) or dumps raw XML (truncates).
+
+**Ask yourself:** what specific domain term would a human point at in the log to say "yes, that's the pass"? *Status 'p'*. *exec_qty=1*. *faultCode 2000*. *The case's external id*. Put that in the criterion. You're not dictating a regex — you're naming a landmark.
+
+**Regex-facing patterns still belong in each step's `expectPatterns`.** This is where XML fragments and exact substrings go. The simple judge enforces those character-for-character. The LLM judge does not see `expectPatterns`; it sees the evidence and your `criteria`, and independently forms a judgment.
 
 ---
 
@@ -107,8 +127,10 @@ That's the regex-facing assertion. Character-exact, fast, no hallucination.
 > The evidence consists of two XML-RPC responses: one from `reportTCResult` (a report acknowledgement), one from `getLastExecutionResult` (the read-back). TestLink encodes execution status as a single character: `p` (passed), `f` (failed), `b` (blocked), empty for no-execution. The read-back response is the source of truth — if it carries `status=f`, the failure was persisted correctly.
 
 `criteria`:
-> Pass: the fail report is acknowledged, and the read-back response shows the same case as failed. A human reading the logs should see both the acknowledgement and the post-report state matching.
-> Fail: the read-back shows a different status, or a fault envelope indicates the report didn't persist.
+> Pass: the fail report is acknowledged, and the read-back response returns the case with status 'f' (failed). A human reading the logs should see the acknowledgement on the report call and the 'f' status field on the getLastExecutionResult struct.
+> Fail: the read-back shows a status other than 'f', or a fault envelope indicates the report didn't persist.
+
+Notice the criterion names *specific terms a reader would point at* — "status 'f' (failed)", "getLastExecutionResult". These are narration, not regex, but they're concrete enough that the LLM judge can cite them short-form when it writes its `evidence` output. Compare with a too-abstract version — *"the read-back response shows the case as failed"* — which reads fine to a human but leaves the LLM with nothing short to quote, so it reaches into raw XML and often truncates.
 
 Notice what's *not* in the `criteria`: character-level substrings. Those went into `expectPatterns`, where they belong. The `criteria` is narrated for a reader; the regex does the character-level work.
 

--- a/docs/feature-requests/FR-004-llm-judge-evidence-grounding.md
+++ b/docs/feature-requests/FR-004-llm-judge-evidence-grounding.md
@@ -1,0 +1,126 @@
+---
+fr: FR-004
+title: LLM judge — enforce grounded evidence citations
+status: draft
+issue: https://github.com/dogkeeper886/testlink-code/issues/14
+authors: ["dogkeeper886"]
+created: 2026-04-20
+updated: 2026-04-20
+---
+
+# FR-004 — LLM judge: enforce grounded evidence citations
+
+## Tracking
+
+- GitHub issue: [#14](https://github.com/dogkeeper886/testlink-code/issues/14)
+- Status: draft
+- Depends on: None
+- Blocks: None (quality improvement; does not gate correctness)
+
+## Problem
+
+The LLM judge's response schema requires an `evidence` field containing "the exact line(s) from OBSERVATIONS that drove the verdict" (see `cicd/tests/src/judge/llm-judge.ts` system message). In practice the field is inconsistently grounded:
+
+- For short, simple tests the model quotes actual response fragments.
+- For longer multi-step tests the model often substitutes a paraphrase of the criteria text, or cites a fragment from the wrong part of the observation.
+
+Concrete observations from run `2026-04-20T02:25:32`:
+
+| Test | Reason field | Evidence field | Grounding |
+|---|---|---|---|
+| TC-SMOKE-001 | cites `"Login"` in stdout | `STDOUT: Login` | ✓ grounded |
+| TC-SMOKE-002 | cites `Hello!` in XML-RPC envelope | `<string>Hello!</string>` | ✓ grounded |
+| TC-AUTH-001 | cites `<boolean>1</boolean>` | `<boolean>1</boolean>` quote from response | ✓ grounded |
+| TC-PLAN-003 | plausible summary of what happened | `"Step 5 response contains feature_id or status with boolean 1. Step 6 stderr contains the case external id or a tc_id field"` — paraphrase of criteria text | ✗ paraphrase |
+| TC-EXEC-001 | cites `status "p"` in lastExecutionResult | `"Step 8 stderr contains the literal fragment ..."` — paraphrase of criteria | ✗ paraphrase |
+| TC-EXEC-003 | cites `<name>exec_qty</name><value><string>1</string>` from stderr | `{"ok": true}` — stdout envelope, wrong part of observation | ✗ wrong fragment |
+
+The verdicts themselves are correct in every case. The problem is evidence quality: a downstream human auditing the run cannot trust that the model actually grounded its verdict in the observations, because the evidence field sometimes proves only that the model can paraphrase its own input.
+
+This erodes trust in the judge for cases where the verdict is the part that matters — principally, future failures, where the evidence field is supposed to be the first place a triager looks.
+
+## Goals
+
+- Every verdict's `evidence` field must be a substring of one of the observation fields (step stdout, step stderr, or container_logs) for that test.
+- When a verdict is `pass: false`, the evidence must quote the specific log line that disproves the claim — not "Step N does not contain X" but the actual Step N contents that led to that conclusion.
+- Framework surfaces evidence/observation mismatch so a human can audit.
+
+## Non-goals
+
+- Changing verdict accuracy. Correct verdicts stay correct; this FR only tightens the auditability of the evidence trail.
+- Switching models. `LLM_JUDGE_MODEL` stays configurable.
+- Re-writing test YAMLs. The per-test fields (`objective`, `judgeContext`, `criteria`) are the test author's responsibility and are not in scope here.
+- Supporting fuzzy / semantic matching of evidence against observations. A substring check is enough.
+
+## Proposed solution
+
+Three independent layers; pick one, pick a combination, or pick all.
+
+### Layer 1 — Tighten the system prompt
+
+Add an explicit rule and an example to `llm-judge.ts`'s system message:
+
+```
+- evidence MUST be an exact substring of the observations you were given.
+  Do not paraphrase the criteria. Quote the log line.
+
+Example (correct): evidence: "<string>b</string>"
+Example (wrong):   evidence: "Step 10 stderr contains the expected status value"
+```
+
+The wrong example deliberately looks like what the model currently produces for long tests, so the contrast is legible.
+
+Lowest-effort, moderate expected effect. Doesn't fix it when the model misbehaves anyway.
+
+### Layer 2 — Post-process validation
+
+After `JSON.parse` in `judgeOne`, check whether `judgment.evidence` appears verbatim (case-insensitive substring) in any of:
+
+- each step's `stdout`
+- each step's `stderr`
+- the `container_logs`
+
+If the evidence is non-empty and doesn't match anywhere, emit a structured log entry `[LLM] WARNING: Evidence not grounded for <testId>: <evidence>` and add a flag on the `Judgment` struct (e.g., `evidenceGrounded: false`). The verdict itself stays — we're auditing, not overriding.
+
+Test reports surface the flag. Triagers know which verdicts to double-check.
+
+### Layer 3 — Retry-with-correction on ungrounded evidence
+
+If Layer 2 detects mismatch, re-prompt the model once with the specific observation it should quote from. Additional cost per retry; bounded by a retry cap.
+
+Probably overkill for a first cut; add only if Layers 1+2 leave too much noise.
+
+## Alternatives considered
+
+- **Ignore it, trust the reason field.** Rejected — reasons are also paraphrased sometimes; evidence was supposed to be the grounded anchor, and if it isn't, we've lost the anchor.
+- **Replace LLM judge with pure regex everywhere.** Rejected — the LLM judge's job is to catch silent-failure cases the simple judge can't. Correctness is fine; auditability is the gap.
+- **Switch to a larger model.** Rejected — this problem is architectural (prompt design + validation), not scale. A larger model would paraphrase less but wouldn't guarantee grounding.
+
+## Acceptance criteria
+
+- After implementation, every verdict in a full suite run has `evidence` appearing as a substring in that test's observation fields.
+- If any verdict's evidence doesn't match, the framework surfaces it clearly (log line + judgment flag + visible in report).
+- Existing tests continue to pass both judges; no regression in verdict accuracy.
+- The judge system prompt documents the evidence-grounding requirement explicitly.
+
+## Risks and tradeoffs
+
+- **Tightening the prompt adds tokens.** The judge prompt is already pushing 7k tokens on the longest tests. Adding examples costs space. Quantify: ~200 tokens for the rule + example; negligible vs. current prompt sizes.
+- **Layer 2 adds complexity.** A warning that's frequently triggered becomes noise. If Layer 1 mostly fixes grounding, most runs won't trigger Layer 2; if it doesn't, the warning is signal.
+- **Substring matching is brittle.** The model might quote a semantically correct fragment with different whitespace, or combine two adjacent fields. Can mitigate with whitespace normalization before comparison.
+
+## Open questions
+
+- _Is substring matching enough, or do we need token-level overlap checks?_ (nice to resolve) — worth starting with substring and raising if we see mismatches we'd consider semantically grounded.
+- _Do we downgrade the verdict to suspect when Layer 2 fails, or just annotate?_ (nice to resolve) — I lean annotate-only, because the verdict might still be right even if the evidence citation is sloppy.
+
+## Implementation notes
+
+- Relevant file: `cicd/tests/src/judge/llm-judge.ts`. Both the system message construction and the `judgeOne` post-processing loop live there.
+- Relevant types: `Judgment` in `cicd/tests/src/types.ts` would need an `evidenceGrounded?: boolean` field for Layer 2.
+- Reporter changes (`cicd/tests/src/reporter/`) to surface the flag in output.
+
+## Out of scope (deferred)
+
+- Changing test authoring guidance. The testcase-author skill and `TESTCASE_AUTHORING.md` remain as-is — this FR does not push new requirements onto test authors.
+- Multi-judge arbitration. If Layers 1-3 aren't enough, a future FR could explore running two judges and comparing.

--- a/docs/feature-requests/README.md
+++ b/docs/feature-requests/README.md
@@ -45,3 +45,4 @@ If you happen to use Claude Code, there's an optional personal skill (`~/.claude
 | [FR-001](./FR-001-extend-functional-test-coverage.md) | Extend functional test coverage | draft | [#7](https://github.com/dogkeeper886/testlink-code/issues/7) |
 | [FR-002](./FR-002-delete-build-and-remove-test-case-from-test-plan.md) | Add `deleteBuild` and `removeTestCaseFromTestPlan` | draft | [#8](https://github.com/dogkeeper886/testlink-code/issues/8) |
 | [FR-003](./FR-003-requirement-spec-and-requirement-crud.md) | Add Requirement Spec + Requirement CRUD | draft | [#9](https://github.com/dogkeeper886/testlink-code/issues/9) |
+| [FR-004](./FR-004-llm-judge-evidence-grounding.md) | LLM judge — enforce grounded evidence citations | draft | [#14](https://github.com/dogkeeper886/testlink-code/issues/14) |


### PR DESCRIPTION
Paired spec for #14.

## Summary

Documents a real issue surfaced during the TC-EXEC-003 fix-verification run: the LLM judge returns correct verdicts but its `evidence` field is inconsistently grounded in the observations. For longer multi-step tests the model paraphrases the criteria text or cites the wrong part of the observation, rather than quoting the actual log fragment.

Tables in the FR doc list the observed cases by test — 3 grounded, 3 ungrounded — so the pattern is concrete, not speculative.

Proposed solution is three independent layers (prompt rule, post-process validation, retry) so the next implementer can scope incrementally.

## Test plan

- [ ] Open `docs/feature-requests/FR-004-llm-judge-evidence-grounding.md`; confirm frontmatter links to #14.
- [ ] Open #14; confirm the `Spec:` line at the top links to FR-004.
- [ ] `docs/feature-requests/README.md` index lists FR-004.

## Follow-ups

- Implementation of FR-004 happens in a separate PR, not this one. This is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)