### PR TITLE
feat(ci): requirement/ suite — FR-001 Phase 2 (TC-REQ-001/002/003)

### DIFF
--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -14,6 +14,7 @@ export const SUITES = [
   'crud',
   'plan',
   'execution',
+  'requirement',
   'workflow',
   'negative',
   'regression',

--- a/cicd/tests/testcases/requirement/TC-REQ-001.yml
+++ b/cicd/tests/testcases/requirement/TC-REQ-001.yml
@@ -1,0 +1,99 @@
+id: TC-REQ-001
+name: Requirement specification CRUD
+suite: requirement
+priority: 1
+timeout: 60000
+dependencies:
+  - TC-AUTH-001
+
+steps:
+  - name: Create parent project (setup)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createTestProject</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectname</name><value><string>proj-{{testId}}-{{runId}}</string></value></member>
+        <member><name>testcaseprefix</name><value><string>RS{{runId}}</string></value></member>
+        <member><name>notes</name><value><string>{{testId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      projectId: "id"
+
+  - name: Create requirement specification under project
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createRequirementSpecification</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>requirementdocid</name><value><string>RS-{{testId}}-{{runId}}</string></value></member>
+        <member><name>title</name><value><string>spec-{{testId}}-{{runId}}</string></value></member>
+        <member><name>scope</name><value><string>Created by {{testId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      specId: "id"
+
+  - name: List specs for the project; verify ours appears
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.getRequirementSpecificationsForTestProject</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "spec-{{testId}}-{{runId}}"
+
+  - name: Delete requirement specification (teardown)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.deleteRequirementSpecification</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>reqspecid</name><value><int>{{specId}}</int></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<boolean>1</boolean>|status.*true"
+
+  - name: Delete parent project (teardown)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.deleteTestProject</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>prefix</name><value><string>RS{{runId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<boolean>1</boolean>|status.*true"
+
+objective: |
+  Confirm the Requirement Specification entity supports full CRUD
+  via XML-RPC. A requirement spec is the container for requirements;
+  without working spec CRUD, no requirement traceability workflow
+  can be automated through the API.
+
+judgeContext: |
+  A requirement spec in TestLink is a node under a test project that
+  holds a collection of requirements. It has a doc_id (unique within
+  the project) and a title (human-readable name).
+
+  tl.createRequirementSpecification returns a struct with the new
+  spec id in the "id" field.
+  tl.getRequirementSpecificationsForTestProject returns a list of
+  spec structs, each carrying "id", "doc_id", and "title" fields.
+  tl.deleteRequirementSpecification returns boolean 1 on success.
+
+criteria: |
+  Pass: tl.createRequirementSpecification returns a new spec id;
+  tl.getRequirementSpecificationsForTestProject response contains
+  the literal title "spec-{{testId}}-{{runId}}";
+  tl.deleteRequirementSpecification returns boolean 1;
+  the parent project delete also returns boolean 1.
+
+  Fail: any step returns a fault envelope; the list does not contain
+  the just-created spec's title; delete fails to acknowledge.

--- a/cicd/tests/testcases/requirement/TC-REQ-002.yml
+++ b/cicd/tests/testcases/requirement/TC-REQ-002.yml
@@ -1,0 +1,126 @@
+id: TC-REQ-002
+name: Requirement CRUD under spec
+suite: requirement
+priority: 2
+timeout: 60000
+dependencies:
+  - TC-REQ-001
+
+steps:
+  - name: Create parent project (setup)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createTestProject</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectname</name><value><string>proj-{{testId}}-{{runId}}</string></value></member>
+        <member><name>testcaseprefix</name><value><string>RQ{{runId}}</string></value></member>
+        <member><name>notes</name><value><string>{{testId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      projectId: "id"
+
+  - name: Create parent requirement specification (setup)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createRequirementSpecification</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>requirementdocid</name><value><string>RS-{{testId}}-{{runId}}</string></value></member>
+        <member><name>title</name><value><string>spec-{{testId}}-{{runId}}</string></value></member>
+        <member><name>scope</name><value><string>{{testId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      specId: "id"
+
+  - name: Create requirement under the spec
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createRequirement</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>reqspecid</name><value><int>{{specId}}</int></value></member>
+        <member><name>requirementdocid</name><value><string>R-{{testId}}-{{runId}}-1</string></value></member>
+        <member><name>title</name><value><string>req-{{testId}}-{{runId}}</string></value></member>
+        <member><name>scope</name><value><string>Created by {{testId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      reqId: "id"
+
+  - name: Read requirement back by id
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.getRequirement</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>requirementid</name><value><int>{{reqId}}</int></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "R-{{testId}}-{{runId}}-1"
+
+  - name: Delete requirement (teardown)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.deleteRequirement</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>requirementid</name><value><int>{{reqId}}</int></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<boolean>1</boolean>|status.*true"
+
+  - name: Delete spec (teardown)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.deleteRequirementSpecification</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>reqspecid</name><value><int>{{specId}}</int></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<boolean>1</boolean>|status.*true"
+
+  - name: Delete parent project (teardown)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.deleteTestProject</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>prefix</name><value><string>RQ{{runId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<boolean>1</boolean>|status.*true"
+
+objective: |
+  Confirm the Requirement entity supports full CRUD under a parent
+  spec via XML-RPC. Requirements are the leaf entity in TestLink's
+  compliance/traceability surface — every downstream feature
+  (assignment to cases, coverage reports) depends on this CRUD path
+  working.
+
+judgeContext: |
+  A requirement in TestLink lives under a requirement specification,
+  which lives under a project. Each requirement has a doc_id
+  (unique within the project) and a title. tl.createRequirement
+  returns the new requirement id in the struct's "id" field, and
+  the existing tl.getRequirement returns a struct whose "req_doc_id"
+  field carries the doc_id that was set at create time.
+
+criteria: |
+  Pass: tl.createRequirement returns a new requirement id;
+  tl.getRequirement response contains the literal req_doc_id
+  "R-{{testId}}-{{runId}}-1" (confirming the requirement persisted
+  with the correct identity); tl.deleteRequirement returns boolean 1;
+  the spec delete and project delete each return boolean 1.
+
+  Fail: any step returns a fault envelope; the read-back doesn't
+  carry the expected req_doc_id; any teardown fails to acknowledge.

--- a/cicd/tests/testcases/requirement/TC-REQ-003.yml
+++ b/cicd/tests/testcases/requirement/TC-REQ-003.yml
@@ -1,0 +1,186 @@
+id: TC-REQ-003
+name: Assign requirement to test case + coverage
+suite: requirement
+priority: 3
+timeout: 60000
+dependencies:
+  - TC-REQ-002
+  - TC-CRUD-003
+
+steps:
+  - name: Create parent project (setup)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createTestProject</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectname</name><value><string>proj-{{testId}}-{{runId}}</string></value></member>
+        <member><name>testcaseprefix</name><value><string>RA{{runId}}</string></value></member>
+        <member><name>notes</name><value><string>{{testId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      projectId: "id"
+
+  - name: Create test suite (setup)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createTestSuite</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>testsuitename</name><value><string>suite-{{testId}}-{{runId}}</string></value></member>
+        <member><name>details</name><value><string>{{testId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      suiteId: "id"
+
+  - name: Create test case (setup)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createTestCase</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testcasename</name><value><string>case-{{testId}}-{{runId}}</string></value></member>
+        <member><name>testsuiteid</name><value><int>{{suiteId}}</int></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>authorlogin</name><value><string>admin</string></value></member>
+        <member><name>summary</name><value><string>{{testId}}</string></value></member>
+        <member><name>steps</name><value><array><data><value><struct>
+          <member><name>step_number</name><value><int>1</int></value></member>
+          <member><name>actions</name><value><string>noop</string></value></member>
+          <member><name>expected_results</name><value><string>ok</string></value></member>
+        </struct></value></data></array></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      caseId: "id"
+
+  - name: Create requirement specification (setup)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createRequirementSpecification</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>requirementdocid</name><value><string>RS-{{testId}}-{{runId}}</string></value></member>
+        <member><name>title</name><value><string>spec-{{testId}}-{{runId}}</string></value></member>
+        <member><name>scope</name><value><string>{{testId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      specId: "id"
+
+  - name: Create requirement (setup)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.createRequirement</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>reqspecid</name><value><int>{{specId}}</int></value></member>
+        <member><name>requirementdocid</name><value><string>R-{{testId}}-{{runId}}-1</string></value></member>
+        <member><name>title</name><value><string>req-{{testId}}-{{runId}}</string></value></member>
+        <member><name>scope</name><value><string>{{testId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<name>id</name>"
+    capture:
+      reqId: "id"
+
+  - name: Assign requirement to the test case
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.assignRequirements</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>testcaseexternalid</name><value><string>RA{{runId}}-1</string></value></member>
+        <member><name>requirements</name><value><array><data><value><struct>
+          <member><name>req_spec</name><value><int>{{specId}}</int></value></member>
+          <member><name>requirements</name><value><array><data><value><int>{{reqId}}</int></value></data></array></value></member>
+        </struct></value></data></array></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "status.*true|<boolean>1</boolean>"
+
+  - name: Read requirement back to confirm it still exists after assignment
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.getRequirement</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>testprojectid</name><value><int>{{projectId}}</int></value></member>
+        <member><name>requirementid</name><value><int>{{reqId}}</int></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "R-{{testId}}-{{runId}}-1"
+
+  - name: Delete requirement (teardown)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.deleteRequirement</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>requirementid</name><value><int>{{reqId}}</int></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<boolean>1</boolean>|status.*true"
+
+  - name: Delete spec (teardown)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.deleteRequirementSpecification</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>reqspecid</name><value><int>{{specId}}</int></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<boolean>1</boolean>|status.*true"
+
+  - name: Delete parent project (teardown)
+    command: |
+      bash cicd/scripts/xmlrpc-capture.sh <<'XMLDOC'
+      <?xml version="1.0"?><methodCall><methodName>tl.deleteTestProject</methodName><params><param><value><struct>
+        <member><name>devKey</name><value><string>{{devKey}}</string></value></member>
+        <member><name>prefix</name><value><string>RA{{runId}}</string></value></member>
+      </struct></value></param></params></methodCall>
+      XMLDOC
+    expectPatterns:
+      - "<boolean>1</boolean>|status.*true"
+
+objective: |
+  Confirm that a requirement can be assigned to a test case and that
+  tl.getReqCoverage reflects the linkage. This is the traceability
+  anchor — compliance workflows rely on the ability to attach
+  requirements to the tests that verify them and to query which
+  cases cover which requirements.
+
+judgeContext: |
+  In TestLink, a requirement can be linked to one or more test cases
+  to express "this test verifies this requirement". tl.assignRequirements
+  creates the link row and returns a status:true acknowledgement on
+  success.
+
+  This test stops at the assignment acknowledgement rather than
+  querying tl.getReqCoverage, which requires a requirement version id
+  (a separate entity from the requirement id) that xmlrpc-capture.sh
+  doesn't currently expose to the test framework's capture mechanism.
+  Extending coverage verification is tracked as a framework follow-up.
+
+criteria: |
+  Pass: tl.assignRequirements returns status:true confirming the
+  assignment endpoint accepted the link;
+  tl.getRequirement response for the same requirement still contains
+  the req_doc_id "R-{{testId}}-{{runId}}-1" (the assignment did not
+  corrupt the requirement's identity);
+  every teardown step returns boolean 1.
+
+  Fail: the assignment returns a fault envelope; the post-assignment
+  read-back can't find the requirement; any teardown fails to
+  acknowledge.

--- a/cicd/tests/testcases/requirement/TC-REQ-003.yml
+++ b/cicd/tests/testcases/requirement/TC-REQ-003.yml
@@ -155,11 +155,13 @@ steps:
       - "<boolean>1</boolean>|status.*true"
 
 objective: |
-  Confirm that a requirement can be assigned to a test case and that
-  tl.getReqCoverage reflects the linkage. This is the traceability
-  anchor — compliance workflows rely on the ability to attach
-  requirements to the tests that verify them and to query which
-  cases cover which requirements.
+  Confirm that a requirement can be assigned to a test case via
+  tl.assignRequirements without corrupting either entity. This is the
+  write half of the traceability path — compliance workflows rely on
+  the ability to attach requirements to the tests that verify them.
+  Querying coverage by requirement is a separate path (tl.getReqCoverage
+  needs a version id the framework's capture mechanism doesn't expose
+  yet) and is out of scope for this test.
 
 judgeContext: |
   In TestLink, a requirement can be linked to one or more test cases


### PR DESCRIPTION
Implements Phase 2 of #7. Exercises the Requirement CRUD methods that landed in PR #17.

## Summary

Three new testcases in a new `requirement/` suite:

- **TC-REQ-001** — Requirement specification CRUD: create → list → delete. Verifies the spec's title appears in the list response verbatim.
- **TC-REQ-002** — Requirement CRUD under a spec: create → read-back (existing `tl.getRequirement`) → delete. Verifies the exact `req_doc_id` persists through the round-trip.
- **TC-REQ-003** — Assign a requirement to a test case via `tl.assignRequirements`, then read the requirement back to confirm the assignment didn't corrupt its identity.

Also registers `requirement` in `config.ts:SUITES`.

## One known limitation in TC-REQ-003

The test originally planned to verify the assignment via `tl.getReqCoverage`, but that endpoint requires the requirement's `version_id` (a separate entity, not the requirement id). `xmlrpc-capture.sh` currently only exposes the `id` field to the framework's `capture:` mechanism, so we can't route `version_id` through cleanly.

Rather than hack around it, TC-REQ-003 stops at the assignment's `status:true` acknowledgement plus a read-back that confirms the requirement still exists. That's a weaker guarantee than "the link is queryable", but enough to prove the assign endpoint accepted the call. Framework enhancement to expose additional captured fields is tracked as a follow-up.

## Results

All three tests pass both judges on first run:

| Test | Simple | LLM |
|---|---|---|
| TC-REQ-001 | ✅ | ✅ |
| TC-REQ-002 | ✅ | ✅ |
| TC-REQ-003 | ✅ | ✅ |

Full suite: **22/22 simple, 21/22 LLM**. The single LLM fail is the pre-existing TC-EXEC-002 model-level flake (unrelated to this PR).

Each LLM verdict for the new tests cites grounded, domain-specific evidence:
- TC-REQ-002: *"expected req_doc_id 'R-TC-REQ-002-1776665769777-1' returned"*
- TC-REQ-003: *"The assignment endpoint returned status:true, and the requirement's ID remained 'R-TC-REQ-003-1776665776735-1' after assignment."*

## Test plan

- [ ] `bash cicd/scripts/run-tests.sh --suite requirement` — 3 tests, all pass.
- [ ] `bash cicd/scripts/run-tests.sh` — 22 tests, ≥ 21 LLM pass (TC-EXEC-002 noise).
- [ ] Running twice back-to-back on a fresh stack is idempotent (run-id suffixes).

## What this closes

- #7 Phase 2 — requirement traceability tests now land.
- With Phase 1 (merged in PR #12) + Phase 3 (TC-WORKFLOW-002 in same PR) + Phase 2 (this PR), issue #7 is complete.

## Follow-ups

- Extend `xmlrpc-capture.sh` to let tests capture arbitrary fields from responses (so TC-REQ-003 can add a real `getReqCoverage` verification step).
- Pre-existing helper bugs flagged in PR #17 (`TL_REQ_SPEC_TYPE_FEATURE` undefined; `get_all_in_testproject` SQL drift) remain open — worked around in the adapters, not fixed at source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)