### PR TITLE
ci(workflows): add runner input; self-hosted runner setup docs — #22

### DIFF
--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -14,6 +14,14 @@ on:
         options:
           - "simple"
           - "dual"
+      runner:
+        description: "Runner to dispatch on. Use self-hosted to reach LAN Ollama."
+        required: false
+        default: "ubuntu-latest"
+        type: choice
+        options:
+          - "ubuntu-latest"
+          - "self-hosted"
 
 jobs:
   build:
@@ -23,6 +31,7 @@ jobs:
     with:
       suite: build
       judge_mode: ${{ inputs.judge_mode || 'simple' }}
+      runner: ${{ inputs.runner || 'ubuntu-latest' }}
 
   smoke:
     name: Smoke Tests
@@ -32,6 +41,7 @@ jobs:
     with:
       suite: smoke
       judge_mode: ${{ inputs.judge_mode || 'simple' }}
+      runner: ${{ inputs.runner || 'ubuntu-latest' }}
 
   auth:
     name: Auth Tests
@@ -41,6 +51,7 @@ jobs:
     with:
       suite: auth
       judge_mode: ${{ inputs.judge_mode || 'simple' }}
+      runner: ${{ inputs.runner || 'ubuntu-latest' }}
 
   crud:
     name: CRUD Tests
@@ -50,6 +61,7 @@ jobs:
     with:
       suite: crud
       judge_mode: ${{ inputs.judge_mode || 'simple' }}
+      runner: ${{ inputs.runner || 'ubuntu-latest' }}
 
   workflow:
     name: Workflow Tests
@@ -59,3 +71,4 @@ jobs:
     with:
       suite: workflow
       judge_mode: ${{ inputs.judge_mode || 'simple' }}
+      runner: ${{ inputs.runner || 'ubuntu-latest' }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,6 +29,14 @@ on:
         required: false
         default: ""
         type: string
+      runner:
+        description: "Runner to dispatch on. Use self-hosted to reach LAN Ollama."
+        required: false
+        default: "ubuntu-latest"
+        type: choice
+        options:
+          - "ubuntu-latest"
+          - "self-hosted"
   workflow_call:
     inputs:
       suite:
@@ -45,6 +53,11 @@ on:
         required: false
         default: ""
         type: string
+      runner:
+        description: "Runner label. 'ubuntu-latest' or 'self-hosted'."
+        required: false
+        default: "ubuntu-latest"
+        type: string
     outputs:
       result:
         description: "Test result"
@@ -53,7 +66,7 @@ on:
 jobs:
   test:
     name: Run ${{ inputs.suite }} Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     outputs:
       result: ${{ steps.run-tests.outcome }}
 

--- a/cicd/CI_SETUP.md
+++ b/cicd/CI_SETUP.md
@@ -38,34 +38,55 @@ When `judge_mode=dual` is dispatched against a GitHub-hosted runner, the LLM jud
 
 ### Prerequisites on the runner host
 
-- Docker installed and the user running the runner is in the `docker` group (`ci-up.sh` uses `docker compose` without `sudo`).
+- Docker installed and the user who will run the runner is in the `docker` group (`ci-up.sh` uses `docker compose` without `sudo`).
 - Network route to the Ollama instance (e.g. `192.168.2.103:11434`).
-- A user account dedicated to the runner.
+- A user account (can be the developer's own — no dedicated account required).
+- `sudo` access for the systemd install step.
+
+### Install location
+
+The runner lives under `/usr/local/actions-runner-testlink-code/` rather than the user's home directory. Systemd's default service context cannot reliably reach files under `$HOME`, so keeping the runner tree outside home avoids a whole class of permission puzzles. The directory is chown'd to the runner user so the service can start without sudo-shimming.
 
 ### Register
 
-1. Go to **Settings → Actions → Runners → New self-hosted runner** on the fork. GitHub generates a single-use registration token (expires in ~1 hour) and shows the download/config commands.
-2. On the runner host:
+1. Go to **Settings → Actions → Runners → New self-hosted runner** on the fork. GitHub generates a single-use registration token (expires in ~1 hour) and shows the current runner version + checksum.
+2. On the runner host, download the tarball to your home directory (not `/usr/local` — keep the one-shot download outside the persistent install path):
    ```
-   mkdir actions-runner && cd actions-runner
-   curl -o actions-runner-linux-x64-<version>.tar.gz -L https://github.com/actions/runner/releases/download/v<version>/actions-runner-linux-x64-<version>.tar.gz
-   tar xzf actions-runner-linux-x64-<version>.tar.gz
-   ./config.sh --url https://github.com/<owner>/testlink-code --token <token>
+   cd ~
+   curl -sSfL -o actions-runner-linux-x64-<version>.tar.gz \
+     https://github.com/actions/runner/releases/download/v<version>/actions-runner-linux-x64-<version>.tar.gz
+   sha256sum actions-runner-linux-x64-<version>.tar.gz   # compare against GitHub's page
    ```
-   Use GitHub's current "New self-hosted runner" page for the exact version number and checksum — this doc intentionally doesn't pin one.
-3. Accept the default `self-hosted` label. The workflows dispatch against the bare `self-hosted` label; no custom labels are needed for a single-runner setup.
+   This doc intentionally doesn't pin a version — check GitHub's "New self-hosted runner" page for the current one.
+3. Create the install path, chown to the user who will run the service, and extract:
+   ```
+   sudo mkdir -p /usr/local/actions-runner-testlink-code
+   sudo chown "$USER:$USER" /usr/local/actions-runner-testlink-code
+   tar xzf ~/actions-runner-linux-x64-<version>.tar.gz \
+     -C /usr/local/actions-runner-testlink-code
+   ```
+4. Register:
+   ```
+   cd /usr/local/actions-runner-testlink-code
+   ./config.sh --unattended \
+     --url https://github.com/<owner>/testlink-code \
+     --token <token>
+   ```
+   `--unattended` accepts defaults for runner group, runner name (the hostname), labels (`self-hosted,Linux,X64`), and work folder (`_work`). The workflows dispatch against the bare `self-hosted` label, which is one of the defaults — no custom labels needed for a single-runner setup.
 
 ### Install as a service (so it survives reboots)
 
-From inside the `actions-runner` directory:
+From `/usr/local/actions-runner-testlink-code/`:
 
 ```
-sudo ./svc.sh install
+sudo ./svc.sh install <user>      # e.g. sudo ./svc.sh install jack
 sudo ./svc.sh start
 sudo ./svc.sh status
 ```
 
-This installs a systemd unit that starts the runner on boot and respawns it if it dies. The alternative, `./run.sh` in the foreground, stops as soon as you close the shell — fine for a first test, not for durable CI.
+Pass the username explicitly — without it, `svc.sh` defaults via `$SUDO_USER`, which is right in interactive shells but not always in automation contexts. The install creates a systemd unit at `/etc/systemd/system/actions.runner.<owner>-<repo>.<hostname>.service`, enables it for boot, and starts it.
+
+Foreground mode (`./run.sh`) works for a first-test sanity check but dies with the shell — use the service install for durable CI.
 
 ### Set the LLM endpoint
 

--- a/cicd/CI_SETUP.md
+++ b/cicd/CI_SETUP.md
@@ -31,3 +31,62 @@ Local developers put these in `cicd/tests/.env` (gitignored). The workflow does 
 ## Local dev is unchanged
 
 Your `cicd/tests/.env` keeps working exactly as before. `run-tests.sh` sources it only when present, and the runner has no `.env` to source.
+
+## Self-hosted runner (for `dual` judge mode with a LAN Ollama)
+
+When `judge_mode=dual` is dispatched against a GitHub-hosted runner, the LLM judge has no way to reach an Ollama instance that only lives on your LAN. The workarounds are (a) expose Ollama publicly behind a secret URL, or (b) register a **self-hosted runner** on a box with network access to it. This section covers option (b).
+
+### Prerequisites on the runner host
+
+- Docker installed and the user running the runner is in the `docker` group (`ci-up.sh` uses `docker compose` without `sudo`).
+- Network route to the Ollama instance (e.g. `192.168.2.103:11434`).
+- A user account dedicated to the runner.
+
+### Register
+
+1. Go to **Settings → Actions → Runners → New self-hosted runner** on the fork. GitHub generates a single-use registration token (expires in ~1 hour) and shows the download/config commands.
+2. On the runner host:
+   ```
+   mkdir actions-runner && cd actions-runner
+   curl -o actions-runner-linux-x64-<version>.tar.gz -L https://github.com/actions/runner/releases/download/v<version>/actions-runner-linux-x64-<version>.tar.gz
+   tar xzf actions-runner-linux-x64-<version>.tar.gz
+   ./config.sh --url https://github.com/<owner>/testlink-code --token <token>
+   ```
+   Use GitHub's current "New self-hosted runner" page for the exact version number and checksum — this doc intentionally doesn't pin one.
+3. Accept the default `self-hosted` label. The workflows dispatch against the bare `self-hosted` label; no custom labels are needed for a single-runner setup.
+
+### Install as a service (so it survives reboots)
+
+From inside the `actions-runner` directory:
+
+```
+sudo ./svc.sh install
+sudo ./svc.sh start
+sudo ./svc.sh status
+```
+
+This installs a systemd unit that starts the runner on boot and respawns it if it dies. The alternative, `./run.sh` in the foreground, stops as soon as you close the shell — fine for a first test, not for durable CI.
+
+### Set the LLM endpoint
+
+In **Settings → Secrets and variables → Actions**:
+
+- `secrets.LLM_JUDGE_URL` = `http://<ollama-host-on-lan>:11434`
+- `vars.LLM_JUDGE_MODEL` = `gemma3:4b` (or whichever model you've pulled on that Ollama)
+
+These flow into the job environment when the workflow dispatches — see the "Secrets and variables" table above.
+
+### Dispatch
+
+In the Actions tab, pick **CI Pipeline** (`test-pipeline.yml`) and dispatch with:
+
+- `judge_mode` = `dual`
+- `runner` = `self-hosted`
+
+For a green-path sanity check without the LLM judge, leave `judge_mode=simple` and `runner=ubuntu-latest` — that keeps using GitHub-hosted infra and the simple regex judge.
+
+### Operational notes
+
+- **Ephemeral workspaces:** the runner's default is persistent — each job reuses the same working directory. `run-tests.sh` tears down the docker-compose stack via `trap EXIT` so state doesn't accumulate across runs, but if you hit weirdness, `docker system prune` on the runner host is safe.
+- **Runner updates:** GitHub updates the runner agent regularly. The installed service auto-updates in most cases, but if a workflow starts failing with a version mismatch, re-run `./config.sh remove` + `./config.sh` with a fresh token to reinstall.
+- **Fallback:** `runs-on` is input-driven, so you can always dispatch against `ubuntu-latest` if the self-hosted box is down or you want to sanity-check on hosted infra.


### PR DESCRIPTION
Closes #22.

## Summary

- Both workflows take a new `runner` input, default `ubuntu-latest`. Operators dispatch with `runner=self-hosted` to route jobs at a runner with LAN access to Ollama.
- `test-pipeline.yml` passes `runner` through to every call of `test-suite.yml`. `test-suite.yml`'s job uses `runs-on: \${{ inputs.runner }}`.
- `cicd/CI_SETUP.md` gets a new \"Self-hosted runner\" section — prerequisites, install-location rationale, registration walkthrough, systemd install, LLM endpoint wiring, dispatch instructions, operational notes. Install convention is `/usr/local/actions-runner-testlink-code/` (chown'd to the runner user, so systemd can start without sudo-shimming).

## Infra state at time of PR

- Runner `dell-e6320` is registered against the repo (labels: `self-hosted, Linux, X64`, status `online`).
- `secrets.LLM_JUDGE_URL` and `vars.LLM_JUDGE_MODEL=gemma3:4b` are set in repo settings.
- Service running at `actions.runner.dogkeeper886-testlink-code.dell-e6320.service`, enabled at boot, runs as `jack` (uid 1000).

## Commit split

- `e518f4dd` — workflow inputs + first pass of the docs.
- `46315dc0` — docs fixup. First pass told readers to install under `\$HOME` while the commit body claimed the install convention is `/usr/local/...`. Self-review caught the drift; this commit reconciles the doc to match what we actually did and what the commit body advertised.

## Test plan

- [ ] Dispatch `test-pipeline.yml` with defaults (`judge_mode=simple`, `runner=ubuntu-latest`) — verify nothing regresses
- [ ] Dispatch `test-pipeline.yml` with `judge_mode=simple`, `runner=self-hosted` — verify the self-hosted runner picks up the job and the simple-judge path runs green
- [ ] Dispatch `test-pipeline.yml` with `judge_mode=dual`, `runner=self-hosted` — verify the LLM judge reaches the LAN Ollama at \`secrets.LLM_JUDGE_URL\` and scores against `vars.LLM_JUDGE_MODEL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)