### PR TITLE
fix(ci): route lifecycle output to stderr — #25

### DIFF
--- a/cicd/scripts/ci-down.sh
+++ b/cicd/scripts/ci-down.sh
@@ -2,6 +2,9 @@
 # Tear down CI environment
 set -e
 
+# Logs/side-effects only — keep stdout clean for callers that capture it.
+exec >&2
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/../docker-compose.ci.yml"
 

--- a/cicd/scripts/ci-up.sh
+++ b/cicd/scripts/ci-up.sh
@@ -2,6 +2,12 @@
 # Start CI environment: build image, start services, init DB, verify health
 set -e
 
+# This script's output is entirely log/side-effect — no data. Send it
+# all to stderr so a caller that captures the wrapper's stdout (e.g.
+# `run-tests.sh ... --format json > results.json`) doesn't end up
+# with docker build output and banner lines interleaved with JSON.
+exec >&2
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/../docker-compose.ci.yml"
 

--- a/cicd/scripts/run-tests.sh
+++ b/cicd/scripts/run-tests.sh
@@ -45,9 +45,9 @@ done
 cleanup() {
   local exit_code=$?
   if [ "$NEEDS_STACK" = "true" ]; then
-    echo ""
-    echo "=== Session teardown (exit code: $exit_code) ==="
-    "$SCRIPT_DIR/ci-down.sh" || echo "[WARN] Teardown failed — inspect containers manually"
+    echo "" >&2
+    echo "=== Session teardown (exit code: $exit_code) ===" >&2
+    "$SCRIPT_DIR/ci-down.sh" || echo "[WARN] Teardown failed — inspect containers manually" >&2
   fi
   exit "$exit_code"
 }
@@ -55,7 +55,7 @@ cleanup() {
 if [ "$NEEDS_STACK" = "true" ]; then
   # Arm the trap before ci-up so a failed startup still triggers teardown.
   trap cleanup EXIT INT TERM
-  echo "=== Session setup ==="
+  echo "=== Session setup ===" >&2
   "$SCRIPT_DIR/ci-up.sh"
 fi
 


### PR DESCRIPTION
Closes #25.

## Summary

Lifecycle scripts (\`ci-up.sh\`, \`ci-down.sh\`) and session banners in \`run-tests.sh\` were echoing to stdout. When the workflow captured \`run-tests.sh ... --format json\`'s stdout into \`/tmp/test-results.json\` and handed it to \`jq\`, the file's first line was \`=== Session setup ===\` — jq tripped on the \`=\` at column 4 and exited 4.

Fix:
- \`ci-up.sh\` and \`ci-down.sh\`: add \`exec >&2\` at the top. Both scripts are side-effect only (no data) so all their output including docker-compose subprocess lines routes to stderr cleanly.
- \`run-tests.sh\`: four session-banner echoes get \`>&2\`. The \`npx tsx src/cli.ts run\` call keeps stdout as-is so the framework's JSON envelope flows through.

## Verification

Locally:
\`\`\`
bash cicd/scripts/run-tests.sh --suite smoke --id TC-SMOKE-002 --no-llm --format json > /tmp/out.json
head -c 40 /tmp/out.json   # starts with '{'
jq -e '.summary.failed' /tmp/out.json   # returns 0 cleanly
\`\`\`

Banners still render on the terminal for interactive runs (stderr is still a TTY).

## Test plan (CI)

- [ ] Dispatch \`test-pipeline.yml\` with \`judge_mode=simple\`, \`runner=self-hosted\` — verify the \"Check test results\" step no longer trips and the full build → smoke → auth → crud → workflow chain runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)