### PR TITLE
fix(ci): export TL_URL / TL_PORT / TL_DEV_KEY defaults for CI — #29

### DIFF
--- a/cicd/scripts/run-tests.sh
+++ b/cicd/scripts/run-tests.sh
@@ -30,6 +30,16 @@ if [ -f "$ENV_FILE" ]; then
   set +a
 fi
 
+# Defaults for values .env provides locally but CI runners don't (no .env
+# on the runner — GitHub's checkout skips gitignored files). The ${VAR:-...}
+# pattern preserves precedence: anything the parent shell or .env set wins;
+# the fallback only fires when the variable is unset or empty. Match the
+# literals in ci-up.sh / xmlrpc-capture.sh so CI behaves like a developer
+# laptop with a populated .env.
+export TL_PORT="${TL_PORT:-8091}"
+export TL_URL="${TL_URL:-http://localhost:${TL_PORT}}"
+export TL_DEV_KEY="${TL_DEV_KEY:-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4}"
+
 ARGS=("$@")
 
 # The build suite lints PHP and builds the image via `docker build`.


### PR DESCRIPTION
Closes #29.

## Summary

In CI the runner has no \`cicd/tests/.env\` (GitHub's checkout skips gitignored files), and the workflow's \`env:\` block doesn't set \`TL_URL\`/\`TL_PORT\`. So when \`run-tests.sh\` spawns \`tsx\`, those variables are unset; YAML steps that use \`\$TL_URL\` expand to nothing, curl errors instantly on a malformed URL, and the step reports empty stdout with exit 0.

Fix: export \`TL_PORT\`, \`TL_URL\`, \`TL_DEV_KEY\` defaults from \`run-tests.sh\` right after the optional \`.env\` source. \`\${VAR:-...}\` preserves precedence — anything set by \`.env\` or the parent shell wins.

## Verification

Reproduced the CI condition locally by running from the self-hosted runner's workdir (\`/usr/local/actions-runner-testlink-code/_work/testlink-code/testlink-code\`) with no \`.env\`:

- **Before fix:** TC-SMOKE-001 failed, TC-SMOKE-002 passed (via \`xmlrpc-capture.sh\`'s own fallback).
- **After fix:** TC-SMOKE-001 and TC-SMOKE-002 both pass (2/2).

## Context — what this closes

Third bug found in the same forensic thread, after #25 (stdout corruption) and while filing #27 (LLM silent fallback) and #28 (\`.env\` override precedence). Order of impact:

1. #25 fix let the pipeline report real test state instead of jq parse errors. (Landed in #26.)
2. With real state visible, TC-SMOKE-001 was revealed as a genuine failure in CI only. This PR's fix handles that — runner env parity with local.
3. After this lands, the \`judge_mode=simple, runner=self-hosted\` pipeline path should be fully green end-to-end.

## Test plan

- [ ] Dispatch \`test-pipeline.yml\` with \`judge_mode=simple\`, \`runner=self-hosted\` — verify all five suites green
- [ ] Local \`bash cicd/scripts/run-tests.sh --suite smoke\` still works with \`.env\` present (precedence preserved)
- [ ] Re-check dual mode later once #27 (LLM fallback masquerade) is handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)