### PR TITLE
fix(ci): caller env wins over .env defaults — #28

### DIFF
--- a/cicd/scripts/ci-up.sh
+++ b/cicd/scripts/ci-up.sh
@@ -12,12 +12,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/../docker-compose.ci.yml"
 
 # Allow direct invocation (outside run-tests.sh) to still pick up .env values.
+# Caller-wins: variables already in the inherited environment are left alone,
+# so overrides like `TL_PORT=9000 bash ci-up.sh` work as expected.
 ENV_FILE="$SCRIPT_DIR/../tests/.env"
 if [ -f "$ENV_FILE" ]; then
-  set -a
-  # shellcheck disable=SC1090
-  . "$ENV_FILE"
-  set +a
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|\#*) continue ;; esac
+    case "$line" in *=*) ;; *) continue ;; esac
+    key="${line%%=*}"
+    value="${line#*=}"
+    if [ -z "${!key+set}" ]; then
+      export "$key=$value"
+    fi
+  done < "$ENV_FILE"
 fi
 
 TL_URL="${TL_URL:-http://localhost:${TL_PORT:-8091}}"

--- a/cicd/scripts/ci-up.sh
+++ b/cicd/scripts/ci-up.sh
@@ -13,7 +13,10 @@ COMPOSE_FILE="$SCRIPT_DIR/../docker-compose.ci.yml"
 
 # Allow direct invocation (outside run-tests.sh) to still pick up .env values.
 # Caller-wins: variables already in the inherited environment are left alone,
-# so overrides like `TL_PORT=9000 bash ci-up.sh` work as expected.
+# so an override like `TL_DEV_KEY=... bash ci-up.sh` takes effect. Note that
+# .env is read as literal `key=value` lines — no bash interpolation, no
+# quote-stripping — which differs from the previous `. "$ENV_FILE"` loader.
+# Correlated vars (e.g. TL_PORT / TL_URL) must be overridden together.
 ENV_FILE="$SCRIPT_DIR/../tests/.env"
 if [ -f "$ENV_FILE" ]; then
   while IFS= read -r line || [ -n "$line" ]; do

--- a/cicd/scripts/run-tests.sh
+++ b/cicd/scripts/run-tests.sh
@@ -24,6 +24,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # reach the tsx CLI. Keep it optional — absent .env means rely on defaults.
 # Caller-wins: a variable already present in the inherited environment is
 # left alone, so `LLM_JUDGE_URL=... bash run-tests.sh ...` works as expected.
+# .env is read as literal `key=value` lines — no bash interpolation, no
+# quote-stripping — which differs from the previous `. "$ENV_FILE"` loader.
 ENV_FILE="$REPO_ROOT/cicd/tests/.env"
 if [ -f "$ENV_FILE" ]; then
   while IFS= read -r line || [ -n "$line" ]; do

--- a/cicd/scripts/run-tests.sh
+++ b/cicd/scripts/run-tests.sh
@@ -22,12 +22,19 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Load cicd/tests/.env if present so LLM_JUDGE_URL / LLM_JUDGE_MODEL etc.
 # reach the tsx CLI. Keep it optional — absent .env means rely on defaults.
+# Caller-wins: a variable already present in the inherited environment is
+# left alone, so `LLM_JUDGE_URL=... bash run-tests.sh ...` works as expected.
 ENV_FILE="$REPO_ROOT/cicd/tests/.env"
 if [ -f "$ENV_FILE" ]; then
-  set -a
-  # shellcheck disable=SC1090
-  . "$ENV_FILE"
-  set +a
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|\#*) continue ;; esac
+    case "$line" in *=*) ;; *) continue ;; esac
+    key="${line%%=*}"
+    value="${line#*=}"
+    if [ -z "${!key+set}" ]; then
+      export "$key=$value"
+    fi
+  done < "$ENV_FILE"
 fi
 
 # Defaults for values .env provides locally but CI runners don't (no .env


### PR DESCRIPTION
## Summary

- `run-tests.sh` and `ci-up.sh` now load `cicd/tests/.env` with a default-only loop: each key is exported only if it isn't already set in the inherited environment.
- Restores the expected Unix behaviour where `VAR=x bash cicd/scripts/run-tests.sh ...` overrides the `.env` value instead of being silently clobbered.
- CI runs are unchanged — no `.env` on the runner, so the loop body never executes and the existing `${VAR:-default}` fallbacks still apply.

## Test plan

- [x] `LLM_JUDGE_URL=http://127.0.0.1:1 bash cicd/scripts/run-tests.sh --suite smoke --id TC-SMOKE-001 --format json` prints `[CONFIG] LLM Judge: http://127.0.0.1:1` (was the `.env` value before the fix).
- [x] `bash cicd/scripts/run-tests.sh --suite smoke` with no override still picks up `LLM_JUDGE_URL` / `LLM_JUDGE_MODEL` from `.env` — both SMOKE tests pass under the real LLM judge.
- [x] CI parity: loop is gated on `[ -f "$ENV_FILE" ]`, and `TL_URL` / `TL_PORT` / `TL_DEV_KEY` defaults remain below the block.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)