### PR TITLE
refactor(ci): LLM judge config via runner .env, not GH secret/var

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -25,7 +25,7 @@ on:
           - "simple"
           - "dual"
       judge_model:
-        description: "LLM model (leave blank to use vars.LLM_JUDGE_MODEL or framework default gemma3:4b)"
+        description: "LLM model (leave blank to use the self-hosted runner's LLM_JUDGE_MODEL or framework default gemma3:4b)"
         required: false
         default: ""
         type: string
@@ -49,7 +49,7 @@ on:
         default: "simple"
         type: string
       judge_model:
-        description: "LLM model override; empty means use vars.LLM_JUDGE_MODEL / framework default"
+        description: "LLM model override; empty means use the runner's LLM_JUDGE_MODEL / framework default"
         required: false
         default: ""
         type: string
@@ -85,19 +85,18 @@ jobs:
       - name: Run tests
         id: run-tests
         env:
-          # Flow secrets/vars through to the test framework. When unset,
-          # the scripts' defaults kick in (see cicd/tests/src/config.ts and
-          # cicd/scripts/init-db.sh). Local dev keeps using cicd/tests/.env
-          # — workflows never materialize that file. See FR-005.
-          LLM_JUDGE_URL: ${{ secrets.LLM_JUDGE_URL }}
-          LLM_JUDGE_MODEL: ${{ vars.LLM_JUDGE_MODEL }}
+          # TL_DEV_KEY is the only LLM/credential value still flowed via GH
+          # secrets — the runner's process env supplies LLM_JUDGE_URL and
+          # LLM_JUDGE_MODEL on self-hosted (see CI_SETUP.md "Set the LLM
+          # endpoint"), and hosted runners don't run dual mode. When unset,
+          # the scripts' defaults kick in (see cicd/scripts/init-db.sh).
           TL_DEV_KEY: ${{ secrets.TL_DEV_KEY }}
         run: |
           # Build judge flags based on input.
           # In dual mode, only append --judge-model when the operator typed
-          # one at dispatch time. Otherwise let LLM_JUDGE_MODEL (from the
-          # env: block above, fed by vars.LLM_JUDGE_MODEL) or the framework
-          # default in config.ts take effect — a CLI flag would shadow them.
+          # one at dispatch time. Otherwise let LLM_JUDGE_MODEL (provided by
+          # the self-hosted runner's root .env) or the framework default in
+          # config.ts take effect — a CLI flag would shadow them.
           JUDGE_FLAGS=""
           if [ "${{ inputs.judge_mode }}" = "simple" ] || [ -z "${{ inputs.judge_mode }}" ]; then
             JUDGE_FLAGS="--no-llm"

--- a/cicd/CI_SETUP.md
+++ b/cicd/CI_SETUP.md
@@ -14,23 +14,17 @@ Switch `judge_mode` to `dual` at dispatch time if you want the LLM judge to run 
 
 ## Secrets and variables
 
-Add these in your fork's **Settings → Secrets and variables → Actions**. All are optional — the framework falls back to defaults when they are unset.
+Add this in your fork's **Settings → Secrets and variables → Actions**. It's optional — the framework falls back to a default when unset.
 
 | Name | Kind | Purpose | Default if unset |
 |---|---|---|---|
-| `LLM_JUDGE_URL` | Secret | Ollama endpoint for the LLM judge | `http://localhost:11434` (unreachable on hosted runners) |
-| `LLM_JUDGE_MODEL` | Variable | Model tag the judge asks Ollama to load | `gemma3:4b` |
 | `TL_DEV_KEY` | Secret | Rotated admin API key (32 hex chars) | `a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4` (seeded by `init-db.sh`) |
 
-Leave them unset for simple-judge-only CI. Set `LLM_JUDGE_URL` + `LLM_JUDGE_MODEL` when you want `dual` mode to work against a real endpoint.
-
-## Why these aren't in a `.env` file on the runner
-
-Local developers put these in `cicd/tests/.env` (gitignored). The workflow does **not** materialize that file on the runner — values flow through the job's `env:` block straight into the test framework's process environment. See FR-005's *Alternatives considered* for the reasoning.
+The LLM judge's endpoint and model are **not** configured via GH secrets/variables. They live in the self-hosted runner's root `.env` (see *Set the LLM endpoint* below) so that the same value the runner reaches at LAN routing time is the one the judge uses, with no GH-side editing required.
 
 ## Local dev is unchanged
 
-Your `cicd/tests/.env` keeps working exactly as before. `run-tests.sh` sources it only when present, and the runner has no `.env` to source.
+Your `cicd/tests/.env` keeps working exactly as before. `run-tests.sh` sources it only when present, and a hosted GitHub runner has no `.env` to source.
 
 ## Self-hosted runner (for `dual` judge mode with a LAN Ollama)
 
@@ -90,12 +84,22 @@ Foreground mode (`./run.sh`) works for a first-test sanity check but dies with t
 
 ### Set the LLM endpoint
 
-In **Settings → Secrets and variables → Actions**:
+The GitHub Actions runner reads `/usr/local/actions-runner-testlink-code/.env` at startup and bakes those vars into every job's process environment. Append the LLM config there:
 
-- `secrets.LLM_JUDGE_URL` = `http://<ollama-host-on-lan>:11434`
-- `vars.LLM_JUDGE_MODEL` = `gemma3:4b` (or whichever model you've pulled on that Ollama)
+```
+LLM_JUDGE_URL=http://<ollama-host-on-lan>:11434
+LLM_JUDGE_MODEL=gemma3:4b
+```
 
-These flow into the job environment when the workflow dispatches — see the "Secrets and variables" table above.
+(Use whichever model you've pulled on that Ollama.)
+
+Restart the service after editing so the new vars are picked up:
+
+```
+sudo systemctl restart actions.runner.<owner>-<repo>.<hostname>.service
+```
+
+The workflow does not flow `LLM_JUDGE_URL` / `LLM_JUDGE_MODEL` through `secrets`/`vars` — they reach the test framework directly from the runner's process env. This keeps the URL co-located with the host that has to route to it; nothing in the GH UI needs editing when your Ollama box's IP changes.
 
 ### Dispatch
 


### PR DESCRIPTION
## Summary

- The self-hosted runner now supplies `LLM_JUDGE_URL` and `LLM_JUDGE_MODEL` via `/usr/local/actions-runner-testlink-code/.env`, which the runner process reads at startup and inherits to every job — same convention as the sibling `actions-runner-ruckus1-mcp` install.
- `.github/workflows/test-suite.yml` no longer threads those vars through `secrets`/`vars`. Empty-secret expansion would otherwise export `LLM_JUDGE_URL=""` and shadow the runner-env value (the `${!key+set}` loader merged in #31 treats empty as set).
- `TL_DEV_KEY` stays as a GH secret — it's a real per-environment credential.
- `cicd/CI_SETUP.md` updated: removed LLM rows from the secrets/vars table, rewrote *Set the LLM endpoint* to point at the runner-root `.env`, dropped the now-stale *Why these aren't in a .env* section.

## Why

The previous design (FR-005) routed the LLM endpoint through GH secrets so the URL never had to live on the runner host. In practice the runner is the only thing that *can* reach the LAN Ollama, so the URL was already host-specific — putting it in GH only added a second place that has to stay in sync. Co-locating it on the runner lets the operator who manages the host also manage the value, which is the same person.

## Test plan

- [ ] Dispatch CI Pipeline on this branch with `judge_mode=dual`, `runner=self-hosted`. Confirm logs show `[JUDGE] Running LLM judge...` followed by `[LLM] ...` evidence lines (not the `[WARN] LLM judge not available` fallback that the prior dual run hit).
- [ ] Confirm hosted-runner simple-mode dispatch still passes (no behavioural change for the no-LLM path).

## Follow-ups (after merge)

- Delete the now-unused `LLM_JUDGE_URL` repo secret and `LLM_JUDGE_MODEL` repo variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)