### PR TITLE
docs: FR-005 post-landing update + test-suite.yml comment fix

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -85,11 +85,11 @@ jobs:
       - name: Run tests
         id: run-tests
         env:
-          # TL_DEV_KEY is the only LLM/credential value still flowed via GH
-          # secrets — the runner's process env supplies LLM_JUDGE_URL and
-          # LLM_JUDGE_MODEL on self-hosted (see CI_SETUP.md "Set the LLM
-          # endpoint"), and hosted runners don't run dual mode. When unset,
-          # the scripts' defaults kick in (see cicd/scripts/init-db.sh).
+          # TL_DEV_KEY is the only credential still flowed via GH secrets;
+          # init-db.sh's default seeds the admin key when it's unset.
+          # LLM_JUDGE_URL and LLM_JUDGE_MODEL come from the self-hosted
+          # runner's process env (see CI_SETUP.md "Set the LLM endpoint").
+          # Hosted runners have neither — dual mode isn't supported there.
           TL_DEV_KEY: ${{ secrets.TL_DEV_KEY }}
         run: |
           # Build judge flags based on input.

--- a/docs/feature-requests/FR-005-github-actions-env-vars-and-secrets.md
+++ b/docs/feature-requests/FR-005-github-actions-env-vars-and-secrets.md
@@ -1,7 +1,7 @@
 ---
 fr: FR-005
 title: Wire GitHub Actions runner with env vars + secrets for the CI suite
-status: in-progress
+status: landed-with-revision
 issue: https://github.com/dogkeeper886/testlink-code/issues/19
 authors: ["dogkeeper886"]
 created: 2026-04-20
@@ -10,10 +10,23 @@ updated: 2026-04-20
 
 # FR-005 — GitHub Actions runner env vars + secrets
 
+## Update — 2026-04-20 (post-landing revision)
+
+The original proposal (below) routed `LLM_JUDGE_URL` and `LLM_JUDGE_MODEL` through GitHub `secrets`/`vars` and explicitly *rejected* the runner-local `.env` alternative. That landed, and then we reversed it in [PR #32](https://github.com/dogkeeper886/testlink-code/pull/32): the LLM judge config now lives in the self-hosted runner's root `.env` (`/usr/local/actions-runner-testlink-code/.env`), matching the convention used by the sibling `actions-runner-ruckus1-mcp` install.
+
+**Why the reversal:** the GH-secrets route was duplicate state. The URL is host-specific (only the runner can route to the LAN Ollama), so it already had to match what the host could reach. Putting it in GH on top of that created two places to keep in sync for zero benefit. The "writes secrets to disk" concern in the original *Alternatives considered* doesn't apply for a LAN URL and a model tag — neither is a real secret.
+
+**Current state:**
+- `TL_DEV_KEY` is still a GH secret (actual per-environment credential).
+- `LLM_JUDGE_URL` / `LLM_JUDGE_MODEL` come from the runner's process env on self-hosted.
+- See `cicd/CI_SETUP.md` "Set the LLM endpoint" for the operational how-to.
+
+The sections below are preserved as written to record the original reasoning; treat them as historical context, not current guidance.
+
 ## Tracking
 
 - GitHub issue: [#19](https://github.com/dogkeeper886/testlink-code/issues/19)
-- Status: draft
+- Status: landed with post-landing revision (PR #21 + PR #32)
 - Depends on: None
 - Blocks: Re-enabling automatic workflow triggers (push / PR) — all workflows are currently `workflow_dispatch` only.
 


### PR DESCRIPTION
## Summary

- **FR-005:** landed proposing GH-secret routing for LLM config; PR #32 reversed that. Added an *Update — 2026-04-20* note near the top explaining the reversal and pointing at the new implementation. Preserved original text as historical context instead of rewriting it. Status flipped from `in-progress` → `landed-with-revision`.
- **`.github/workflows/test-suite.yml`:** fixed muddled comment that called `TL_DEV_KEY` an *"LLM/credential value"* — reads as if `TL_DEV_KEY` is LLM config, which it isn't. Split into two clean sentences.

## Test plan

- [x] No code changes — docs + comment only. Read back both diffs to confirm accuracy.
- [x] FR-005 status frontmatter updated to match reality.

Addresses the two nits from the #32 review. No follow-up needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)